### PR TITLE
Revamp admin and waiter experience

### DIFF
--- a/restaurant_app/lib/app_router.dart
+++ b/restaurant_app/lib/app_router.dart
@@ -2,7 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'features/auth/auth_gate.dart';
 import 'features/auth/login_screen.dart';
-import 'features/admin/dashboard_screen.dart';
+import 'features/admin/admin_shell.dart';
 import 'features/waiter/table_select_screen.dart';
 
 final appRouterProvider = Provider<GoRouter>((ref) {
@@ -11,7 +11,7 @@ final appRouterProvider = Provider<GoRouter>((ref) {
     routes: [
       GoRoute(path: '/', builder: (c, s) => const AuthGate()),
       GoRoute(path: '/login', builder: (c, s) => const LoginScreen()),
-      GoRoute(path: '/admin', builder: (c, s) => const DashboardScreen()),
+      GoRoute(path: '/admin', builder: (c, s) => const AdminShell()),
       GoRoute(path: '/waiter', builder: (c, s) => const TableSelectScreen()),
     ],
   );

--- a/restaurant_app/lib/features/admin/admin_shell.dart
+++ b/restaurant_app/lib/features/admin/admin_shell.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+
+import 'dashboard_screen.dart';
+import 'menu_management_screen.dart';
+import 'table_management_screen.dart';
+
+class AdminShell extends StatefulWidget {
+  const AdminShell({super.key});
+
+  @override
+  State<AdminShell> createState() => _AdminShellState();
+}
+
+class _AdminShellState extends State<AdminShell> {
+  int _currentIndex = 0;
+
+  final _pages = const [
+    DashboardScreen(),
+    TableManagementScreen(),
+    MenuManagementScreen(),
+  ];
+
+  final _titles = const [
+    'Panel de control',
+    'Mesas',
+    'Catálogo',
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Container(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [Color(0xFFFFF6CC), Color(0xFFFFE082)],
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+          ),
+        ),
+        child: SafeArea(
+          child: Column(
+            children: [
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+                child: Row(
+                  children: [
+                    CircleAvatar(
+                      radius: 26,
+                      backgroundColor: Colors.black,
+                      child: Text(
+                        _titles[_currentIndex][0],
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontWeight: FontWeight.bold,
+                          fontSize: 20,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 16),
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'Golden Burger',
+                          style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                                fontWeight: FontWeight.bold,
+                                color: Colors.black,
+                              ),
+                        ),
+                        Text(
+                          _titles[_currentIndex],
+                          style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                                color: Colors.black54,
+                              ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+              Expanded(
+                child: ClipRRect(
+                  borderRadius: const BorderRadius.only(
+                    topLeft: Radius.circular(24),
+                    topRight: Radius.circular(24),
+                  ),
+                  child: Container(
+                    color: Theme.of(context).scaffoldBackgroundColor,
+                    child: IndexedStack(
+                      index: _currentIndex,
+                      children: _pages,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+      bottomNavigationBar: NavigationBar(
+        backgroundColor: const Color(0xFFFFC107),
+        indicatorColor: Colors.black,
+        selectedIndex: _currentIndex,
+        onDestinationSelected: (value) => setState(() => _currentIndex = value),
+        destinations: const [
+          NavigationDestination(
+            icon: Icon(Icons.dashboard_outlined),
+            selectedIcon: Icon(Icons.dashboard, color: Colors.white),
+            label: 'Dashboard',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.table_bar_outlined),
+            selectedIcon: Icon(Icons.table_bar, color: Colors.white),
+            label: 'Mesas',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.restaurant_menu_outlined),
+            selectedIcon: Icon(Icons.restaurant_menu, color: Colors.white),
+            label: 'Catálogo',
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/restaurant_app/lib/features/admin/dashboard_screen.dart
+++ b/restaurant_app/lib/features/admin/dashboard_screen.dart
@@ -12,7 +12,7 @@ class DashboardScreen extends StatefulWidget {
 class _DashboardScreenState extends State<DashboardScreen> {
   late final String _dayId;
   late final String _monthId;
-  final NumberFormat _currencyFormat = NumberFormat.simpleCurrency(locale: 'es');
+  final NumberFormat _currencyFormat = NumberFormat.simpleCurrency(name: 'USD');
 
   @override
   void initState() {
@@ -40,14 +40,38 @@ class _DashboardScreenState extends State<DashboardScreen> {
         .limit(5);
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Admin · Dashboard')),
+      backgroundColor: Colors.transparent,
       body: SingleChildScrollView(
-        padding: const EdgeInsets.all(16),
+        padding: const EdgeInsets.all(20),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Hola, administrador',
+                      style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                            fontWeight: FontWeight.bold,
+                          ),
+                    ),
+                    const SizedBox(height: 4),
+                    const Text('Revisa el rendimiento de Golden Burger'),
+                  ],
+                ),
+                CircleAvatar(
+                  radius: 28,
+                  backgroundColor: Colors.black,
+                  child: const Icon(Icons.bar_chart_rounded, color: Colors.white),
+                ),
+              ],
+            ),
+            const SizedBox(height: 20),
             const _SectionTitle('Hoy'),
-            const SizedBox(height: 8),
+            const SizedBox(height: 12),
             StreamBuilder<DocumentSnapshot<Map<String, dynamic>>>(
               stream: dailyRef.snapshots(),
               builder: (context, snapshot) {
@@ -59,29 +83,37 @@ class _DashboardScreenState extends State<DashboardScreen> {
                 final orders = (data['ordersCount'] ?? 0) as num;
                 final expenses = (data['expensesTotal'] ?? 0).toDouble();
                 final net = (data['netTotal'] ?? (sales - expenses)).toDouble();
-                return Wrap(
-                  spacing: 12,
-                  runSpacing: 12,
+                return GridView.count(
+                  crossAxisCount: MediaQuery.of(context).size.width > 900 ? 4 : 2,
+                  shrinkWrap: true,
+                  physics: const NeverScrollableScrollPhysics(),
+                  mainAxisSpacing: 16,
+                  crossAxisSpacing: 16,
+                  childAspectRatio: 1.6,
                   children: [
                     _MetricTile(
                       title: 'Ventas',
                       value: _currencyFormat.format(sales),
                       icon: Icons.attach_money,
+                      accentColor: const Color(0xFF1DE9B6),
                     ),
                     _MetricTile(
                       title: 'Pedidos',
                       value: orders.toString(),
                       icon: Icons.receipt_long,
+                      accentColor: const Color(0xFFFFC107),
                     ),
                     _MetricTile(
                       title: 'Gastos',
                       value: _currencyFormat.format(expenses),
                       icon: Icons.money_off,
+                      accentColor: const Color(0xFFFF7043),
                     ),
                     _MetricTile(
                       title: 'Neto',
                       value: _currencyFormat.format(net),
                       icon: Icons.trending_up,
+                      accentColor: const Color(0xFF42A5F5),
                     ),
                   ],
                 );
@@ -89,7 +121,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
             ),
             const SizedBox(height: 24),
             const _SectionTitle('Este mes'),
-            const SizedBox(height: 8),
+            const SizedBox(height: 12),
             StreamBuilder<DocumentSnapshot<Map<String, dynamic>>>(
               stream: monthlyRef.snapshots(),
               builder: (context, snapshot) {
@@ -102,34 +134,43 @@ class _DashboardScreenState extends State<DashboardScreen> {
                 final dineIn = (data['dineInTotal'] ?? 0).toDouble();
                 final online = (data['onlineTotal'] ?? 0).toDouble();
                 final orders = (data['ordersCount'] ?? 0) as num;
-                return Wrap(
-                  spacing: 12,
-                  runSpacing: 12,
+                return GridView.count(
+                  crossAxisCount: MediaQuery.of(context).size.width > 900 ? 3 : 1,
+                  shrinkWrap: true,
+                  physics: const NeverScrollableScrollPhysics(),
+                  mainAxisSpacing: 16,
+                  crossAxisSpacing: 16,
+                  childAspectRatio: 3,
                   children: [
                     _MetricTile(
                       title: 'Ventas',
                       value: _currencyFormat.format(sales),
                       icon: Icons.shopping_bag,
+                      accentColor: const Color(0xFF4CAF50),
                     ),
                     _MetricTile(
                       title: 'Pedidos',
                       value: orders.toString(),
                       icon: Icons.list_alt,
+                      accentColor: const Color(0xFF651FFF),
                     ),
                     _MetricTile(
                       title: 'Gastos',
                       value: _currencyFormat.format(expenses),
                       icon: Icons.request_quote,
+                      accentColor: const Color(0xFFFF6F00),
                     ),
                     _MetricTile(
                       title: 'Dine-in',
                       value: _currencyFormat.format(dineIn),
                       icon: Icons.storefront,
+                      accentColor: const Color(0xFF00796B),
                     ),
                     _MetricTile(
                       title: 'Online',
                       value: _currencyFormat.format(online),
                       icon: Icons.wifi,
+                      accentColor: const Color(0xFF00ACC1),
                     ),
                   ],
                 );
@@ -137,7 +178,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
             ),
             const SizedBox(height: 24),
             const _SectionTitle('Últimos pedidos'),
-            const SizedBox(height: 8),
+            const SizedBox(height: 12),
             StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
               stream: recentOrdersQuery.snapshots(),
               builder: (context, snapshot) {
@@ -160,13 +201,42 @@ class _DashboardScreenState extends State<DashboardScreen> {
                         ? DateFormat('dd/MM HH:mm').format(createdAt)
                         : '—';
                     return Card(
-                      child: ListTile(
-                        leading: CircleAvatar(
-                          child: Text('$orderNumber'),
+                      margin: const EdgeInsets.symmetric(vertical: 8),
+                      child: Padding(
+                        padding: const EdgeInsets.all(16),
+                        child: Row(
+                          children: [
+                            CircleAvatar(
+                              backgroundColor: Colors.black,
+                              foregroundColor: Colors.white,
+                              child: Text('$orderNumber'),
+                            ),
+                            const SizedBox(width: 16),
+                            Expanded(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Text(
+                                    _currencyFormat.format(total),
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .titleMedium
+                                        ?.copyWith(fontWeight: FontWeight.bold),
+                                  ),
+                                  const SizedBox(height: 4),
+                                  Wrap(
+                                    spacing: 8,
+                                    children: [
+                                      _StatusChip(label: 'Canal: $channel'),
+                                      _StatusChip(label: 'Estado: ${_statusLabel(status)}'),
+                                    ],
+                                  ),
+                                ],
+                              ),
+                            ),
+                            Text(dateStr),
+                          ],
                         ),
-                        title: Text('Total ${_currencyFormat.format(total)}'),
-                        subtitle: Text('Canal: $channel · Estado: $status'),
-                        trailing: Text(dateStr),
                       ),
                     );
                   }).toList(),
@@ -185,23 +255,31 @@ class _MetricTile extends StatelessWidget {
     required this.title,
     required this.value,
     required this.icon,
+    required this.accentColor,
   });
 
   final String title;
   final String value;
   final IconData icon;
+  final Color accentColor;
 
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-      width: 180,
       child: Card(
         child: Padding(
           padding: const EdgeInsets.all(16),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Icon(icon, color: Theme.of(context).colorScheme.primary),
+              Container(
+                padding: const EdgeInsets.all(10),
+                decoration: BoxDecoration(
+                  color: accentColor.withOpacity(.15),
+                  shape: BoxShape.circle,
+                ),
+                child: Icon(icon, color: accentColor),
+              ),
               const SizedBox(height: 12),
               Text(
                 title,
@@ -237,5 +315,36 @@ class _SectionTitle extends StatelessWidget {
           .titleLarge
           ?.copyWith(fontWeight: FontWeight.bold),
     );
+  }
+}
+
+class _StatusChip extends StatelessWidget {
+  const _StatusChip({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Chip(
+      backgroundColor: const Color(0xFFFFF3CD),
+      side: const BorderSide(color: Color(0xFFFFC107)),
+      label: Text(
+        label,
+        style: const TextStyle(fontWeight: FontWeight.w500),
+      ),
+    );
+  }
+}
+
+String _statusLabel(String status) {
+  switch (status) {
+    case 'open':
+      return 'Abierto';
+    case 'paid':
+      return 'Pagado';
+    case 'cancelled':
+      return 'Cancelado';
+    default:
+      return status;
   }
 }

--- a/restaurant_app/lib/features/admin/menu_management_screen.dart
+++ b/restaurant_app/lib/features/admin/menu_management_screen.dart
@@ -1,0 +1,265 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../../models/menu_item.dart';
+
+class MenuManagementScreen extends StatefulWidget {
+  const MenuManagementScreen({super.key});
+
+  @override
+  State<MenuManagementScreen> createState() => _MenuManagementScreenState();
+}
+
+class _MenuManagementScreenState extends State<MenuManagementScreen> {
+  final NumberFormat _currencyFormat = NumberFormat.simpleCurrency(name: 'USD');
+
+  Future<void> _openItemForm(
+    BuildContext context, {
+    MenuItemModel? item,
+    String? presetCategory,
+  }) async {
+    final formKey = GlobalKey<FormState>();
+    final nameCtrl = TextEditingController(text: item?.name ?? '');
+    final categoryCtrl = TextEditingController(
+      text: item?.category ?? presetCategory ?? 'Hamburguesas',
+    );
+    final priceCtrl = TextEditingController(
+      text: item != null ? item.price.toStringAsFixed(2) : '',
+    );
+    final descriptionCtrl = TextEditingController(text: item?.description ?? '');
+    bool isAvailable = item?.isAvailable ?? true;
+
+    await showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.white,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+      ),
+      builder: (context) {
+        return Padding(
+          padding: EdgeInsets.only(
+            bottom: MediaQuery.of(context).viewInsets.bottom + 20,
+            left: 20,
+            right: 20,
+            top: 24,
+          ),
+          child: Form(
+            key: formKey,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  item == null ? 'Nuevo producto' : 'Editar producto',
+                  style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                ),
+                const SizedBox(height: 16),
+                TextFormField(
+                  controller: nameCtrl,
+                  decoration: const InputDecoration(labelText: 'Nombre'),
+                  validator: (value) {
+                    if (value == null || value.isEmpty) {
+                      return 'Ingresa el nombre';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 12),
+                TextFormField(
+                  controller: categoryCtrl,
+                  decoration: const InputDecoration(labelText: 'Categoría'),
+                ),
+                const SizedBox(height: 12),
+                TextFormField(
+                  controller: descriptionCtrl,
+                  minLines: 2,
+                  maxLines: 3,
+                  decoration: const InputDecoration(labelText: 'Descripción'),
+                ),
+                const SizedBox(height: 12),
+                TextFormField(
+                  controller: priceCtrl,
+                  keyboardType: const TextInputType.numberWithOptions(decimal: true),
+                  decoration: const InputDecoration(labelText: 'Precio (USD)'),
+                  validator: (value) {
+                    final parsed = double.tryParse(value ?? '');
+                    if (parsed == null) {
+                      return 'Ingresa un precio válido';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 12),
+                SwitchListTile.adaptive(
+                  contentPadding: EdgeInsets.zero,
+                  value: isAvailable,
+                  title: const Text('Disponible'),
+                  onChanged: (value) => setState(() => isAvailable = value),
+                ),
+                const SizedBox(height: 12),
+                FilledButton(
+                  onPressed: () async {
+                    if (!formKey.currentState!.validate()) return;
+                    final price = double.parse(priceCtrl.text);
+                    final description = descriptionCtrl.text.trim();
+                    final data = {
+                      'name': nameCtrl.text.trim(),
+                      'category': categoryCtrl.text.trim(),
+                      'price': price,
+                      'description': description.isEmpty ? null : description,
+                      'isAvailable': isAvailable,
+                      'updatedAt': FieldValue.serverTimestamp(),
+                    };
+                    final collection =
+                        FirebaseFirestore.instance.collection('menu_items');
+                    if (item == null) {
+                      await collection.add({
+                        ...data,
+                        'createdAt': FieldValue.serverTimestamp(),
+                      });
+                    } else {
+                      await collection.doc(item.id).update(data);
+                    }
+                    if (context.mounted) {
+                      Navigator.of(context).pop();
+                    }
+                  },
+                  child: Text(item == null ? 'Crear producto' : 'Guardar cambios'),
+                ),
+                const SizedBox(height: 12),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.transparent,
+      body: StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+        stream: FirebaseFirestore.instance
+            .collection('menu_items')
+            .orderBy('category')
+            .orderBy('name')
+            .snapshots(),
+        builder: (context, snapshot) {
+          if (!snapshot.hasData) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final items = snapshot.data!.docs
+              .map((doc) => MenuItemModel.fromMap(doc.id, doc.data()))
+              .toList();
+          if (items.isEmpty) {
+            return Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Icon(Icons.restaurant_menu, size: 72, color: Colors.black45),
+                  const SizedBox(height: 16),
+                  const Text(
+                    'Aún no hay productos en el catálogo.',
+                    style: TextStyle(fontWeight: FontWeight.w600),
+                  ),
+                  const SizedBox(height: 8),
+                  FilledButton.icon(
+                    onPressed: () => _openItemForm(context),
+                    icon: const Icon(Icons.add),
+                    label: const Text('Agregar producto'),
+                  ),
+                ],
+              ),
+            );
+          }
+
+          final grouped = <String, List<MenuItemModel>>{};
+          for (final item in items) {
+            grouped.putIfAbsent(item.category, () => []).add(item);
+          }
+
+          return ListView(
+            padding: const EdgeInsets.all(16),
+            children: grouped.entries.map((entry) {
+              final category = entry.key;
+              final products = entry.value;
+              return Card(
+                margin: const EdgeInsets.only(bottom: 20),
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          Icon(Icons.local_dining, color: Colors.black87),
+                          const SizedBox(width: 8),
+                          Text(
+                            category,
+                            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                                  fontWeight: FontWeight.bold,
+                                ),
+                          ),
+                          const Spacer(),
+                          IconButton(
+                            icon: const Icon(Icons.add_circle_outline),
+                            onPressed: () => _openItemForm(
+                              context,
+                              presetCategory: category,
+                            ),
+                          ),
+                        ],
+                      ),
+                      const Divider(),
+                      ...products.map((product) {
+                        return ListTile(
+                          contentPadding: EdgeInsets.zero,
+                          title: Text(product.name),
+                          subtitle: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(product.description?.isNotEmpty == true
+                                  ? product.description!
+                                  : 'Sin descripción'),
+                              const SizedBox(height: 4),
+                              Text(product.isAvailable ? 'Disponible' : 'Agotado'),
+                            ],
+                          ),
+                          trailing: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Text(
+                                _currencyFormat.format(product.price),
+                                style: const TextStyle(fontWeight: FontWeight.bold),
+                              ),
+                              IconButton(
+                                icon: const Icon(Icons.edit),
+                                onPressed: () => _openItemForm(context, item: product),
+                              ),
+                            ],
+                          ),
+                        );
+                      }),
+                    ],
+                  ),
+                ),
+              );
+            }).toList(),
+          );
+        },
+      ),
+      floatingActionButton: FloatingActionButton.extended(
+        backgroundColor: Colors.black,
+        foregroundColor: Colors.white,
+        onPressed: () => _openItemForm(context),
+        icon: const Icon(Icons.add),
+        label: const Text('Nuevo producto'),
+      ),
+    );
+  }
+}

--- a/restaurant_app/lib/features/admin/table_management_screen.dart
+++ b/restaurant_app/lib/features/admin/table_management_screen.dart
@@ -1,0 +1,263 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+
+import '../../models/restaurant_table.dart';
+
+class TableManagementScreen extends StatelessWidget {
+  const TableManagementScreen({super.key});
+
+  Future<void> _openForm(BuildContext context, {RestaurantTable? table}) async {
+    final formKey = GlobalKey<FormState>();
+    final numberCtrl = TextEditingController(text: table?.number.toString() ?? '');
+    final seatsCtrl = TextEditingController(text: table?.seats.toString() ?? '4');
+    String status = table?.status ?? 'free';
+
+    await showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.white,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+      ),
+      builder: (context) {
+        return Padding(
+          padding: EdgeInsets.only(
+            bottom: MediaQuery.of(context).viewInsets.bottom + 20,
+            left: 20,
+            right: 20,
+            top: 24,
+          ),
+          child: Form(
+            key: formKey,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  table == null ? 'Registrar mesa' : 'Editar mesa',
+                  style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                ),
+                const SizedBox(height: 16),
+                TextFormField(
+                  controller: numberCtrl,
+                  keyboardType: TextInputType.number,
+                  decoration: const InputDecoration(labelText: 'Número de mesa'),
+                  validator: (value) {
+                    if (value == null || value.isEmpty) {
+                      return 'Ingresa un número';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 12),
+                TextFormField(
+                  controller: seatsCtrl,
+                  keyboardType: TextInputType.number,
+                  decoration: const InputDecoration(labelText: 'Capacidad (personas)'),
+                  validator: (value) {
+                    if (value == null || value.isEmpty) {
+                      return 'Ingresa la capacidad';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 12),
+                DropdownButtonFormField<String>(
+                  value: status,
+                  decoration: const InputDecoration(labelText: 'Estado'),
+                  items: const [
+                    DropdownMenuItem(value: 'free', child: Text('Disponible')),
+                    DropdownMenuItem(value: 'occupied', child: Text('Ocupada')),
+                    DropdownMenuItem(value: 'reserved', child: Text('Reservada')),
+                    DropdownMenuItem(value: 'cleaning', child: Text('En limpieza')),
+                  ],
+                  onChanged: (value) => status = value ?? 'free',
+                ),
+                const SizedBox(height: 20),
+                FilledButton(
+                  onPressed: () async {
+                    if (!formKey.currentState!.validate()) return;
+                    final number = int.tryParse(numberCtrl.text.trim()) ?? 0;
+                    final seats = int.tryParse(seatsCtrl.text.trim()) ?? 4;
+                    final data = {
+                      'number': number,
+                      'seats': seats,
+                      'status': status,
+                      'updatedAt': FieldValue.serverTimestamp(),
+                    };
+                    final tablesRef =
+                        FirebaseFirestore.instance.collection('tables');
+                    if (table == null) {
+                      await tablesRef.add({
+                        ...data,
+                        'createdAt': FieldValue.serverTimestamp(),
+                      });
+                    } else {
+                      await tablesRef.doc(table.id).update(data);
+                    }
+                    if (context.mounted) {
+                      Navigator.of(context).pop();
+                    }
+                  },
+                  child: Text(table == null ? 'Guardar mesa' : 'Actualizar mesa'),
+                ),
+                const SizedBox(height: 12),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Color _statusColor(String status) {
+    switch (status) {
+      case 'free':
+        return const Color(0xFF4CAF50);
+      case 'occupied':
+        return const Color(0xFFFF7043);
+      case 'reserved':
+        return const Color(0xFF42A5F5);
+      case 'cleaning':
+        return const Color(0xFF8D6E63);
+      default:
+        return Colors.grey;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.transparent,
+      body: StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+        stream: FirebaseFirestore.instance
+            .collection('tables')
+            .orderBy('number')
+            .snapshots(),
+        builder: (context, snapshot) {
+          if (!snapshot.hasData) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final tables = snapshot.data!.docs
+              .map((doc) => RestaurantTable.fromMap(doc.id, doc.data()))
+              .toList();
+          if (tables.isEmpty) {
+            return Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Icon(Icons.table_bar, size: 72, color: Colors.black45),
+                  const SizedBox(height: 16),
+                  const Text(
+                    'Todavía no has registrado mesas.',
+                    style: TextStyle(fontWeight: FontWeight.w600),
+                  ),
+                  const SizedBox(height: 8),
+                  FilledButton.icon(
+                    onPressed: () => _openForm(context),
+                    icon: const Icon(Icons.add),
+                    label: const Text('Agregar primera mesa'),
+                  ),
+                ],
+              ),
+            );
+          }
+          return Padding(
+            padding: const EdgeInsets.all(16),
+            child: GridView.builder(
+              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: 2,
+                childAspectRatio: 1.2,
+                crossAxisSpacing: 16,
+                mainAxisSpacing: 16,
+              ),
+              itemCount: tables.length,
+              itemBuilder: (context, index) {
+                final table = tables[index];
+                final color = _statusColor(table.status);
+                return GestureDetector(
+                  onTap: () => _openForm(context, table: table),
+                  child: Card(
+                    elevation: 4,
+                    shadowColor: color.withOpacity(.3),
+                    child: Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Row(
+                            children: [
+                              CircleAvatar(
+                                backgroundColor: color.withOpacity(.15),
+                                child: Icon(Icons.table_bar, color: color),
+                              ),
+                              const Spacer(),
+                              IconButton(
+                                icon: const Icon(Icons.edit_outlined),
+                                onPressed: () => _openForm(context, table: table),
+                              ),
+                            ],
+                          ),
+                          const SizedBox(height: 12),
+                          Text(
+                            'Mesa ${table.number}',
+                            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                                  fontWeight: FontWeight.bold,
+                                ),
+                          ),
+                          const SizedBox(height: 4),
+                          Text('Capacidad: ${table.seats} personas'),
+                          const Spacer(),
+                          Chip(
+                            backgroundColor: color.withOpacity(.15),
+                            side: BorderSide(color: color.withOpacity(.4)),
+                            label: Text(
+                              _statusLabel(table.status),
+                              style: TextStyle(color: color.darken()),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                );
+              },
+            ),
+          );
+        },
+      ),
+      floatingActionButton: FloatingActionButton.extended(
+        backgroundColor: Colors.black,
+        foregroundColor: Colors.white,
+        onPressed: () => _openForm(context),
+        icon: const Icon(Icons.add),
+        label: const Text('Nueva mesa'),
+      ),
+    );
+  }
+
+  String _statusLabel(String status) {
+    switch (status) {
+      case 'free':
+        return 'Disponible';
+      case 'occupied':
+        return 'Ocupada';
+      case 'reserved':
+        return 'Reservada';
+      case 'cleaning':
+        return 'En limpieza';
+      default:
+        return 'Desconocido';
+    }
+  }
+}
+
+extension _ColorUtils on Color {
+  Color darken([double amount = .2]) {
+    final hsl = HSLColor.fromColor(this);
+    final hslDark = hsl.withLightness((hsl.lightness - amount).clamp(0.0, 1.0));
+    return hslDark.toColor();
+  }
+}

--- a/restaurant_app/lib/features/auth/login_screen.dart
+++ b/restaurant_app/lib/features/auth/login_screen.dart
@@ -108,76 +108,117 @@ class _LoginScreenState extends State<LoginScreen> {
   Widget build(BuildContext context) {
     final busy = _emailLoading || _googleLoading;
     return Scaffold(
-      appBar: AppBar(title: const Text('Acceder')),
-      body: Center(
-        child: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 420),
-          child: Padding(
-            padding: const EdgeInsets.all(24),
-            child: Form(
-              key: _formKey,
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  TextFormField(
-                    controller: _emailCtrl,
-                    decoration: const InputDecoration(labelText: 'Email'),
-                    keyboardType: TextInputType.emailAddress,
-                    validator: (value) {
-                      if (value == null || value.trim().isEmpty) {
-                        return 'Ingresa tu correo';
-                      }
-                      if (!value.contains('@')) {
-                        return 'Correo inválido';
-                      }
-                      return null;
-                    },
+      body: Container(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [Color(0xFFFFF9C4), Color(0xFFFFECB3)],
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+          ),
+        ),
+        child: SafeArea(
+          child: Center(
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 420),
+              child: Card(
+                elevation: 8,
+                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
+                child: Padding(
+                  padding: const EdgeInsets.all(32),
+                  child: Form(
+                    key: _formKey,
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: const [
+                            Icon(Icons.lunch_dining, size: 36, color: Colors.black),
+                            SizedBox(width: 8),
+                            Text(
+                              'Golden Burger',
+                              style: TextStyle(
+                                fontSize: 24,
+                                fontWeight: FontWeight.w800,
+                              ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 8),
+                        Text(
+                          'Bienvenido de nuevo',
+                          textAlign: TextAlign.center,
+                          style: Theme.of(context).textTheme.titleMedium,
+                        ),
+                        const SizedBox(height: 24),
+                        TextFormField(
+                          controller: _emailCtrl,
+                          decoration: const InputDecoration(
+                            labelText: 'Correo electrónico',
+                            prefixIcon: Icon(Icons.alternate_email),
+                          ),
+                          keyboardType: TextInputType.emailAddress,
+                          validator: (value) {
+                            if (value == null || value.trim().isEmpty) {
+                              return 'Ingresa tu correo';
+                            }
+                            if (!value.contains('@')) {
+                              return 'Correo inválido';
+                            }
+                            return null;
+                          },
+                        ),
+                        const SizedBox(height: 16),
+                        TextFormField(
+                          controller: _passCtrl,
+                          decoration: const InputDecoration(
+                            labelText: 'Contraseña',
+                            prefixIcon: Icon(Icons.lock_outline),
+                          ),
+                          obscureText: true,
+                          validator: (value) {
+                            if (value == null || value.isEmpty) {
+                              return 'Ingresa tu contraseña';
+                            }
+                            if (value.length < 6) {
+                              return 'Debe tener al menos 6 caracteres';
+                            }
+                            return null;
+                          },
+                        ),
+                        const SizedBox(height: 24),
+                        FilledButton(
+                          onPressed: busy ? null : _loginWithEmail,
+                          child: _emailLoading
+                              ? const SizedBox(
+                                  height: 20,
+                                  width: 20,
+                                  child: CircularProgressIndicator(strokeWidth: 2),
+                                )
+                              : const Text('Ingresar'),
+                        ),
+                        const SizedBox(height: 12),
+                        OutlinedButton.icon(
+                          onPressed: busy ? null : _loginWithGoogle,
+                          icon: _googleLoading
+                              ? const SizedBox(
+                                  height: 20,
+                                  width: 20,
+                                  child: CircularProgressIndicator(strokeWidth: 2),
+                                )
+                              : const Icon(Icons.login),
+                          label: const Text('Continuar con Google'),
+                        ),
+                        const SizedBox(height: 16),
+                        const Text(
+                          'Si el correo no existe se creará una cuenta automáticamente. El primer usuario registrado obtiene rol de administrador.',
+                          textAlign: TextAlign.center,
+                        ),
+                      ],
+                    ),
                   ),
-                  const SizedBox(height: 12),
-                  TextFormField(
-                    controller: _passCtrl,
-                    decoration: const InputDecoration(labelText: 'Contraseña'),
-                    obscureText: true,
-                    validator: (value) {
-                      if (value == null || value.isEmpty) {
-                        return 'Ingresa tu contraseña';
-                      }
-                      if (value.length < 6) {
-                        return 'Debe tener al menos 6 caracteres';
-                      }
-                      return null;
-                    },
-                  ),
-                  const SizedBox(height: 24),
-                  FilledButton(
-                    onPressed: busy ? null : _loginWithEmail,
-                    child: _emailLoading
-                        ? const SizedBox(
-                            height: 20,
-                            width: 20,
-                            child: CircularProgressIndicator(strokeWidth: 2),
-                          )
-                        : const Text('Ingresar con email'),
-                  ),
-                  const SizedBox(height: 12),
-                  OutlinedButton.icon(
-                    onPressed: busy ? null : _loginWithGoogle,
-                    icon: _googleLoading
-                        ? const SizedBox(
-                            height: 20,
-                            width: 20,
-                            child: CircularProgressIndicator(strokeWidth: 2),
-                          )
-                        : const Icon(Icons.login),
-                    label: const Text('Continuar con Google'),
-                  ),
-                  const SizedBox(height: 12),
-                  const Text(
-                    'Si el correo no existe se creará una cuenta automáticamente. El primer usuario registrado obtiene rol de administrador.',
-                    textAlign: TextAlign.center,
-                  ),
-                ],
+                ),
               ),
             ),
           ),

--- a/restaurant_app/lib/features/waiter/cart_screen.dart
+++ b/restaurant_app/lib/features/waiter/cart_screen.dart
@@ -1,50 +1,141 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
-
+import 'package:intl/intl.dart';
 
 class CartScreen extends StatelessWidget {
-final String orderId;
-const CartScreen({super.key, required this.orderId});
+  const CartScreen({super.key, required this.orderId});
 
+  final String orderId;
 
-@override
-Widget build(BuildContext context) {
-return Scaffold(
-appBar: AppBar(title: Text('Pedido #$orderId')),
-body: StreamBuilder<DocumentSnapshot<Map<String, dynamic>>>(
-stream: FirebaseFirestore.instance.collection('orders').doc(orderId).snapshots(),
-builder: (context, snap) {
-if (!snap.hasData) return const Center(child: CircularProgressIndicator());
-final data = snap.data!.data()!;
-final items = (data['items'] as List).cast<Map<String, dynamic>>();
-final total = (data['total'] ?? 0).toDouble();
-final status = data['status'] as String;
-return Column(
-children: [
-Expanded(
-child: ListView.builder(
-itemCount: items.length,
-itemBuilder: (_, i) => ListTile(
-title: Text(items[i]['name']),
-trailing: Text('${items[i]['qty']} x \$${(items[i]['unitPrice'] as num).toStringAsFixed(2)}'),
-subtitle: Text('Subtotal: \$${(items[i]['subtotal'] as num).toStringAsFixed(2)}'),
-),
-),
-),
-Padding(
-padding: const EdgeInsets.all(16),
-child: Row(
-mainAxisAlignment: MainAxisAlignment.spaceBetween,
-children: [
-Text('Estado: $status'),
-Text('Total: \$${total.toStringAsFixed(2)}', style: const TextStyle(fontWeight: FontWeight.bold)),
-],
-),
-)
-],
-);
-},
-),
-);
+  @override
+  Widget build(BuildContext context) {
+    final currencyFormat = NumberFormat.simpleCurrency(name: 'USD');
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Pedido #$orderId'),
+      ),
+      body: Container(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [Color(0xFFFFF6CC), Color(0xFFFFE082)],
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+          ),
+        ),
+        child: StreamBuilder<DocumentSnapshot<Map<String, dynamic>>>(
+          stream: FirebaseFirestore.instance
+              .collection('orders')
+              .doc(orderId)
+              .snapshots(),
+          builder: (context, snapshot) {
+            if (!snapshot.hasData) {
+              return const Center(child: CircularProgressIndicator());
+            }
+            final data = snapshot.data!.data();
+            if (data == null) {
+              return const Center(child: Text('No se encontró la información del pedido.'));
+            }
+            final items = (data['items'] as List).cast<Map<String, dynamic>>();
+            final total = (data['total'] ?? 0).toDouble();
+            final status = (data['status'] ?? 'open') as String;
+            final channel = (data['channel'] ?? 'dine-in') as String;
+
+            return SafeArea(
+              child: Column(
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.all(20),
+                    child: Card(
+                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+                      child: Padding(
+                        padding: const EdgeInsets.all(16),
+                        child: Row(
+                          children: [
+                            const Icon(Icons.receipt_long, size: 32),
+                            const SizedBox(width: 12),
+                            Expanded(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Text(
+                                    'Resumen del pedido',
+                                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                                          fontWeight: FontWeight.bold,
+                                        ),
+                                  ),
+                                  const SizedBox(height: 4),
+                                  Text('Canal: ${_channelLabel(channel)} · Estado: ${_statusLabel(status)}'),
+                                ],
+                              ),
+                            ),
+                            Chip(
+                              backgroundColor: Colors.black,
+                              labelStyle: const TextStyle(color: Colors.white),
+                              label: Text(currencyFormat.format(total)),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                  Expanded(
+                    child: ListView.builder(
+                      padding: const EdgeInsets.symmetric(horizontal: 20),
+                      itemCount: items.length,
+                      itemBuilder: (context, index) {
+                        final item = items[index];
+                        final qty = (item['qty'] as num).toInt();
+                        final unit = (item['unitPrice'] as num).toDouble();
+                        final subtotal = (item['subtotal'] as num).toDouble();
+                        return Card(
+                          margin: const EdgeInsets.only(bottom: 16),
+                          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(18)),
+                          child: ListTile(
+                            leading: CircleAvatar(
+                              backgroundColor: const Color(0xFFFFC107).withOpacity(.2),
+                              child: Text('${index + 1}'),
+                            ),
+                            title: Text(item['name'] as String? ?? 'Producto'),
+                            subtitle: Text('$qty × ${currencyFormat.format(unit)}'),
+                            trailing: Text(
+                              currencyFormat.format(subtotal),
+                              style: const TextStyle(fontWeight: FontWeight.bold),
+                            ),
+                          ),
+                        );
+                      },
+                    ),
+                  ),
+                ],
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
 }
+
+String _statusLabel(String status) {
+  switch (status) {
+    case 'open':
+      return 'Abierto';
+    case 'paid':
+      return 'Pagado';
+    case 'cancelled':
+      return 'Cancelado';
+    default:
+      return status;
+  }
+}
+
+String _channelLabel(String channel) {
+  switch (channel) {
+    case 'dine-in':
+      return 'En mesa';
+    case 'online':
+      return 'Online';
+    default:
+      return channel;
+  }
 }

--- a/restaurant_app/lib/features/waiter/table_select_screen.dart
+++ b/restaurant_app/lib/features/waiter/table_select_screen.dart
@@ -10,83 +10,151 @@ class TableSelectScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Mesas')),
-      body: StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
-        stream: FirebaseFirestore.instance
-            .collection('tables')
-            .orderBy('number')
-            .snapshots(),
-        builder: (context, snapshot) {
-          if (!snapshot.hasData) {
-            return const Center(child: CircularProgressIndicator());
-          }
-          final tables = snapshot.data!.docs
-              .map((doc) => RestaurantTable.fromMap(doc.id, doc.data()))
-              .toList();
-          if (tables.isEmpty) {
-            return const Center(child: Text('Aún no hay mesas registradas.'));
-          }
-          return GridView.builder(
-            padding: const EdgeInsets.all(12),
-            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-              crossAxisCount: 3,
-              childAspectRatio: 1.1,
-              mainAxisSpacing: 8,
-              crossAxisSpacing: 8,
-            ),
-            itemCount: tables.length,
-            itemBuilder: (context, index) {
-              final table = tables[index];
-              final Color color;
-              switch (table.status) {
-                case 'free':
-                  color = Colors.green;
-                  break;
-                case 'occupied':
-                  color = Colors.orange;
-                  break;
-                case 'reserved':
-                  color = Colors.blueAccent;
-                  break;
-                default:
-                  color = Colors.grey;
-              }
-              return InkWell(
-                onTap: () {
-                  Navigator.of(context).push(
-                    MaterialPageRoute(
-                      builder: (_) => MenuScreen(tableId: table.id),
-                    ),
-                  );
-                },
-                child: Card(
-                  child: Center(
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
+      body: Container(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [Color(0xFFFFF6CC), Color(0xFFFFE082)],
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+          ),
+        ),
+        child: SafeArea(
+          child: Column(
+            children: [
+              Padding(
+                padding: const EdgeInsets.fromLTRB(20, 20, 20, 12),
+                child: Row(
+                  children: [
+                    const Icon(Icons.table_bar, size: 32, color: Colors.black),
+                    const SizedBox(width: 12),
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Text(
-                          'Mesa ${table.number}',
-                          style: const TextStyle(
-                            fontSize: 18,
-                            fontWeight: FontWeight.bold,
-                          ),
+                          'Selecciona una mesa',
+                          style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                                fontWeight: FontWeight.bold,
+                              ),
                         ),
-                        const SizedBox(height: 6),
-                        Chip(
-                          label: Text(table.status),
-                          backgroundColor: color.withOpacity(.15),
-                          side: BorderSide(color: color.withOpacity(.6)),
-                        ),
+                        const SizedBox(height: 4),
+                        const Text('Visualiza disponibilidad en tiempo real'),
                       ],
+                    ),
+                  ],
+                ),
+              ),
+              Expanded(
+                child: ClipRRect(
+                  borderRadius: const BorderRadius.only(
+                    topLeft: Radius.circular(28),
+                    topRight: Radius.circular(28),
+                  ),
+                  child: Container(
+                    color: Theme.of(context).scaffoldBackgroundColor,
+                    child: StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+                      stream: FirebaseFirestore.instance
+                          .collection('tables')
+                          .orderBy('number')
+                          .snapshots(),
+                      builder: (context, snapshot) {
+                        if (!snapshot.hasData) {
+                          return const Center(child: CircularProgressIndicator());
+                        }
+                        final tables = snapshot.data!.docs
+                            .map((doc) => RestaurantTable.fromMap(doc.id, doc.data()))
+                            .toList();
+                        if (tables.isEmpty) {
+                          return const Center(
+                            child: Text('Aún no hay mesas registradas.'),
+                          );
+                        }
+                        return GridView.builder(
+                          padding: const EdgeInsets.all(20),
+                          gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                            crossAxisCount: 2,
+                            childAspectRatio: 1.2,
+                            mainAxisSpacing: 20,
+                            crossAxisSpacing: 20,
+                          ),
+                          itemCount: tables.length,
+                          itemBuilder: (context, index) {
+                            final table = tables[index];
+                            final status = _statusLabel(table.status);
+                            final color = _statusColor(table.status);
+                            return InkWell(
+                              borderRadius: BorderRadius.circular(24),
+                              onTap: () {
+                                Navigator.of(context).push(
+                                  MaterialPageRoute(
+                                    builder: (_) => MenuScreen(tableId: table.id),
+                                  ),
+                                );
+                              },
+                              child: Card(
+                                elevation: 6,
+                                shadowColor: color.withOpacity(.3),
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(24),
+                                ),
+                                child: Padding(
+                                  padding: const EdgeInsets.all(20),
+                                  child: Column(
+                                    crossAxisAlignment: CrossAxisAlignment.start,
+                                    children: [
+                                      Row(
+                                        children: [
+                                          CircleAvatar(
+                                            backgroundColor: color.withOpacity(.15),
+                                            child: Icon(Icons.event_seat, color: color),
+                                          ),
+                                          const Spacer(),
+                                          Text(
+                                            '#${table.number}',
+                                            style: const TextStyle(
+                                              fontSize: 18,
+                                              fontWeight: FontWeight.bold,
+                                            ),
+                                          ),
+                                        ],
+                                      ),
+                                      const Spacer(),
+                                      Text(
+                                        '${table.seats} comensales',
+                                        style: Theme.of(context).textTheme.labelLarge,
+                                      ),
+                                      const SizedBox(height: 6),
+                                      Chip(
+                                        backgroundColor: color.withOpacity(.18),
+                                        side: BorderSide(
+                                          color: color.withOpacity(.4),
+                                        ),
+                                        label: Text(
+                                          status,
+                                          style: TextStyle(
+                                            color: color.darken(),
+                                            fontWeight: FontWeight.w600,
+                                          ),
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                              ),
+                            );
+                          },
+                        );
+                      },
                     ),
                   ),
                 ),
-              );
-            },
-          );
-        },
+              ),
+            ],
+          ),
+        ),
       ),
       floatingActionButton: FloatingActionButton.extended(
+        backgroundColor: Colors.black,
+        foregroundColor: Colors.white,
         onPressed: () {
           Navigator.of(context).push(
             MaterialPageRoute(builder: (_) => const MenuScreen()),
@@ -96,5 +164,43 @@ class TableSelectScreen extends StatelessWidget {
         icon: const Icon(Icons.shopping_bag_outlined),
       ),
     );
+  }
+}
+
+Color _statusColor(String status) {
+  switch (status) {
+    case 'free':
+      return const Color(0xFF4CAF50);
+    case 'occupied':
+      return const Color(0xFFFF7043);
+    case 'reserved':
+      return const Color(0xFF42A5F5);
+    case 'cleaning':
+      return const Color(0xFF8D6E63);
+    default:
+      return Colors.grey;
+  }
+}
+
+String _statusLabel(String status) {
+  switch (status) {
+    case 'free':
+      return 'Disponible';
+    case 'occupied':
+      return 'Ocupada';
+    case 'reserved':
+      return 'Reservada';
+    case 'cleaning':
+      return 'En limpieza';
+    default:
+      return status;
+  }
+}
+
+extension _ColorDarken on Color {
+  Color darken([double amount = .2]) {
+    final hsl = HSLColor.fromColor(this);
+    final hslDark = hsl.withLightness((hsl.lightness - amount).clamp(0.0, 1.0));
+    return hslDark.toColor();
   }
 }

--- a/restaurant_app/lib/main.dart
+++ b/restaurant_app/lib/main.dart
@@ -6,26 +6,68 @@ import 'app_router.dart';
 
 
 Future<void> main() async {
-WidgetsFlutterBinding.ensureInitialized();
-await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
-runApp(const ProviderScope(child: RestaurantApp()));
+  WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
+  runApp(const ProviderScope(child: RestaurantApp()));
 }
-
 
 class RestaurantApp extends ConsumerWidget {
-const RestaurantApp({super.key});
+  const RestaurantApp({super.key});
 
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final router = ref.watch(appRouterProvider);
+    final colorScheme = ColorScheme.fromSeed(
+      seedColor: const Color(0xFFFFC107),
+      brightness: Brightness.light,
+    ).copyWith(
+      primary: const Color(0xFFFFC107),
+      onPrimary: Colors.black,
+      secondary: const Color(0xFF212121),
+      onSecondary: Colors.white,
+      surface: Colors.white,
+      onSurface: const Color(0xFF1A1A1A),
+    );
 
-@override
-Widget build(BuildContext context, WidgetRef ref) {
-final router = ref.watch(appRouterProvider);
-return MaterialApp.router(
-title: 'Restaurant App',
-routerConfig: router,
-theme: ThemeData(
-useMaterial3: true,
-colorSchemeSeed: Colors.teal,
-),
-);
-}
+    return MaterialApp.router(
+      title: 'Golden Burger',
+      routerConfig: router,
+      theme: ThemeData(
+        useMaterial3: true,
+        colorScheme: colorScheme,
+        scaffoldBackgroundColor: const Color(0xFFFDF7E3),
+        appBarTheme: AppBarTheme(
+          backgroundColor: const Color(0xFFFFC107),
+          foregroundColor: Colors.black,
+          elevation: 0,
+          titleTextStyle: const TextStyle(
+            fontSize: 20,
+            fontWeight: FontWeight.bold,
+            color: Colors.black,
+          ),
+        ),
+        cardTheme: CardTheme(
+          color: Colors.white,
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+          elevation: 2,
+        ),
+        filledButtonTheme: FilledButtonThemeData(
+          style: FilledButton.styleFrom(
+            backgroundColor: const Color(0xFF212121),
+            foregroundColor: Colors.white,
+            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+            textStyle: const TextStyle(fontWeight: FontWeight.bold),
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+          ),
+        ),
+        inputDecorationTheme: InputDecorationTheme(
+          border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
+          focusedBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(12),
+            borderSide: const BorderSide(color: Color(0xFFFFC107), width: 2),
+          ),
+        ),
+      ),
+    );
+  }
 }

--- a/restaurant_app/lib/models/menu_item.dart
+++ b/restaurant_app/lib/models/menu_item.dart
@@ -1,39 +1,42 @@
 class MenuItemModel {
-final String id;
-final String name;
-final String category;
-final double price;
-final bool isAvailable;
-final String? imageUrl;
+  final String id;
+  final String name;
+  final String category;
+  final double price;
+  final bool isAvailable;
+  final String? imageUrl;
+  final String? description;
 
+  MenuItemModel({
+    required this.id,
+    required this.name,
+    required this.category,
+    required this.price,
+    required this.isAvailable,
+    this.imageUrl,
+    this.description,
+  });
 
-MenuItemModel({
-required this.id,
-required this.name,
-required this.category,
-required this.price,
-required this.isAvailable,
-this.imageUrl,
-});
+  factory MenuItemModel.fromMap(String id, Map<String, dynamic> data) {
+    return MenuItemModel(
+      id: id,
+      name: data['name'] ?? '',
+      category: data['category'] ?? 'General',
+      price: (data['price'] ?? 0).toDouble(),
+      isAvailable: data['isAvailable'] ?? true,
+      imageUrl: data['imageUrl'] as String?,
+      description: data['description'] as String?,
+    );
+  }
 
-
-factory MenuItemModel.fromMap(String id, Map<String, dynamic> data) {
-return MenuItemModel(
-id: id,
-name: data['name'] ?? '',
-category: data['category'] ?? 'General',
-price: (data['price'] ?? 0).toDouble(),
-isAvailable: data['isAvailable'] ?? true,
-imageUrl: data['imageUrl'],
-);
-}
-
-
-Map<String, dynamic> toMap() => {
-'name': name,
-'category': category,
-'price': price,
-'isAvailable': isAvailable,
-'imageUrl': imageUrl,
-};
+  Map<String, dynamic> toMap() {
+    return {
+      'name': name,
+      'category': category,
+      'price': price,
+      'isAvailable': isAvailable,
+      'imageUrl': imageUrl,
+      if (description != null && description!.isNotEmpty) 'description': description,
+    };
+  }
 }


### PR DESCRIPTION
## Summary
- introduce an admin shell with navigation to the dashboard, tables, and catalog management plus CRUD forms for each area
- refresh branding, theming, and dashboard presentation to use the restaurant’s yellow/black palette and display financial metrics in USD
- redesign waiter flows for table selection, ordering, and carts with modern cards and gradients that match the new style

## Testing
- not run (Flutter SDK is not available in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68e134c8aae48320986c32ab119f93a3