### PR TITLE
Add waiter order management and catalog categories

### DIFF
--- a/restaurant_app/lib/features/admin/menu_management_screen.dart
+++ b/restaurant_app/lib/features/admin/menu_management_screen.dart
@@ -1,7 +1,9 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
+import '../../models/category.dart';
 import '../../models/menu_item.dart';
 
 class MenuManagementScreen extends StatefulWidget {
@@ -13,11 +15,13 @@ class MenuManagementScreen extends StatefulWidget {
 
 class _MenuManagementScreenState extends State<MenuManagementScreen> {
   final NumberFormat _currencyFormat = NumberFormat.simpleCurrency(name: 'USD');
+  List<String> _cachedCategories = const [];
 
   Future<void> _openItemForm(
     BuildContext context, {
     MenuItemModel? item,
     String? presetCategory,
+    List<String> availableCategories = const [],
   }) async {
     final formKey = GlobalKey<FormState>();
     final nameCtrl = TextEditingController(text: item?.name ?? '');
@@ -30,6 +34,10 @@ class _MenuManagementScreenState extends State<MenuManagementScreen> {
     final descriptionCtrl = TextEditingController(text: item?.description ?? '');
     bool isAvailable = item?.isAvailable ?? true;
     final messenger = ScaffoldMessenger.of(context);
+
+    String? selectedCategory = availableCategories.contains(categoryCtrl.text)
+        ? categoryCtrl.text
+        : null;
 
     await showModalBottomSheet(
       context: context,
@@ -75,7 +83,39 @@ class _MenuManagementScreenState extends State<MenuManagementScreen> {
                     TextFormField(
                       controller: categoryCtrl,
                       decoration: const InputDecoration(labelText: 'Categoría'),
+                      onChanged: (value) {
+                        setModalState(() {
+                          selectedCategory = availableCategories.contains(value)
+                              ? value
+                              : null;
+                        });
+                      },
                     ),
+                    if (availableCategories.isNotEmpty) ...[
+                      const SizedBox(height: 12),
+                      Text(
+                        'Categorías registradas',
+                        style: Theme.of(context).textTheme.labelLarge,
+                      ),
+                      const SizedBox(height: 8),
+                      Wrap(
+                        spacing: 8,
+                        runSpacing: 8,
+                        children: availableCategories.map((category) {
+                          final selected = selectedCategory == category;
+                          return ChoiceChip(
+                            label: Text(category),
+                            selected: selected,
+                            onSelected: (_) {
+                              setModalState(() {
+                                selectedCategory = category;
+                                categoryCtrl.text = category;
+                              });
+                            },
+                          );
+                        }).toList(),
+                      ),
+                    ],
                     const SizedBox(height: 12),
                     TextFormField(
                       controller: descriptionCtrl,
@@ -173,122 +213,303 @@ class _MenuManagementScreenState extends State<MenuManagementScreen> {
     );
   }
 
+  Future<void> _openCategoryForm(BuildContext context) async {
+    final formKey = GlobalKey<FormState>();
+    final nameCtrl = TextEditingController();
+    final messenger = ScaffoldMessenger.of(context);
+
+    await showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Nueva categoría'),
+          content: Form(
+            key: formKey,
+            child: TextFormField(
+              controller: nameCtrl,
+              autofocus: true,
+              decoration: const InputDecoration(
+                labelText: 'Nombre de la categoría',
+              ),
+              validator: (value) {
+                if (value == null || value.trim().isEmpty) {
+                  return 'Ingresa un nombre válido';
+                }
+                return null;
+              },
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('Cancelar'),
+            ),
+            FilledButton(
+              onPressed: () async {
+                if (!formKey.currentState!.validate()) return;
+                final name = nameCtrl.text.trim();
+                try {
+                  await FirebaseFirestore.instance.collection('categories').add({
+                    'name': name,
+                    'createdAt': FieldValue.serverTimestamp(),
+                  });
+                  if (context.mounted) {
+                    Navigator.of(context).pop();
+                  }
+                  messenger.showSnackBar(
+                    const SnackBar(content: Text('Categoría creada correctamente.')),
+                  );
+                } on FirebaseException catch (e) {
+                  messenger.showSnackBar(
+                    SnackBar(
+                      content:
+                          Text(e.message ?? 'No se pudo crear la categoría.'),
+                    ),
+                  );
+                }
+              },
+              child: const Text('Guardar'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildCategoriesCard(
+    BuildContext context,
+    List<CategoryModel> categories,
+  ) {
+    return Card(
+      margin: const EdgeInsets.only(bottom: 20),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Icon(Icons.category, color: Colors.black87),
+                const SizedBox(width: 8),
+                Text(
+                  'Categorías',
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                ),
+                const Spacer(),
+                IconButton(
+                  onPressed: () => _openCategoryForm(context),
+                  icon: const Icon(Icons.add_circle_outline),
+                ),
+              ],
+            ),
+            const Divider(),
+            if (categories.isEmpty)
+              const Text('Aún no hay categorías registradas.'),
+            if (categories.isNotEmpty)
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: categories
+                    .map(
+                      (category) => Chip(
+                        label: Text(category.name),
+                      ),
+                    )
+                    .toList(),
+              ),
+            if (categories.isEmpty)
+              Padding(
+                padding: const EdgeInsets.only(top: 12),
+                child: FilledButton.icon(
+                  onPressed: () => _openCategoryForm(context),
+                  icon: const Icon(Icons.add),
+                  label: const Text('Crear categoría'),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: Colors.transparent,
       body: StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
         stream: FirebaseFirestore.instance
-            .collection('menu_items')
+            .collection('categories')
+            .orderBy('name')
             .snapshots(),
-        builder: (context, snapshot) {
-          if (!snapshot.hasData) {
+        builder: (context, categoriesSnapshot) {
+          if (categoriesSnapshot.connectionState == ConnectionState.waiting) {
             return const Center(child: CircularProgressIndicator());
           }
-          final items = snapshot.data!.docs
-              .map((doc) => MenuItemModel.fromMap(doc.id, doc.data()))
-              .toList();
-          if (items.isEmpty) {
-            return Center(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  const Icon(Icons.restaurant_menu, size: 72, color: Colors.black45),
-                  const SizedBox(height: 16),
-                  const Text(
-                    'Aún no hay productos en el catálogo.',
-                    style: TextStyle(fontWeight: FontWeight.w600),
-                  ),
-                  const SizedBox(height: 8),
-                  FilledButton.icon(
-                    onPressed: () => _openItemForm(context),
-                    icon: const Icon(Icons.add),
-                    label: const Text('Agregar producto'),
-                  ),
-                ],
-              ),
-            );
+
+          final categories = categoriesSnapshot.hasData
+              ? categoriesSnapshot.data!.docs
+                  .map((doc) => CategoryModel.fromMap(doc.id, doc.data()))
+                  .toList()
+              : <CategoryModel>[];
+          final categoryNames = categories.map((c) => c.name).toList();
+          if (!listEquals(_cachedCategories, categoryNames)) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              if (!mounted) return;
+              setState(() {
+                _cachedCategories = categoryNames;
+              });
+            });
           }
 
-          final grouped = <String, List<MenuItemModel>>{};
-          for (final item in items) {
-            grouped.putIfAbsent(item.category, () => []).add(item);
-          }
-
-          return ListView(
-            padding: const EdgeInsets.all(16),
-            children: grouped.entries.map((entry) {
-              final category = entry.key;
-              final products = entry.value;
-              return Card(
-                margin: const EdgeInsets.only(bottom: 20),
-                child: Padding(
+          return StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+            stream: FirebaseFirestore.instance
+                .collection('menu_items')
+                .snapshots(),
+            builder: (context, snapshot) {
+              if (!snapshot.hasData) {
+                return const Center(child: CircularProgressIndicator());
+              }
+              final items = snapshot.data!.docs
+                  .map((doc) => MenuItemModel.fromMap(doc.id, doc.data()))
+                  .toList();
+              if (items.isEmpty) {
+                return ListView(
                   padding: const EdgeInsets.all(16),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Row(
-                        children: [
-                          Icon(Icons.local_dining, color: Colors.black87),
-                          const SizedBox(width: 8),
-                          Text(
-                            category,
-                            style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                                  fontWeight: FontWeight.bold,
-                                ),
-                          ),
-                          const Spacer(),
-                          IconButton(
-                            icon: const Icon(Icons.add_circle_outline),
-                            onPressed: () => _openItemForm(
-                              context,
-                              presetCategory: category,
+                  children: [
+                    _buildCategoriesCard(context, categories),
+                    const SizedBox(height: 12),
+                    Card(
+                      child: Padding(
+                        padding: const EdgeInsets.all(24),
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            const Icon(Icons.restaurant_menu,
+                                size: 72, color: Colors.black45),
+                            const SizedBox(height: 16),
+                            const Text(
+                              'Aún no hay productos en el catálogo.',
+                              style: TextStyle(fontWeight: FontWeight.w600),
                             ),
-                          ),
-                        ],
+                            const SizedBox(height: 8),
+                            FilledButton.icon(
+                              onPressed: () => _openItemForm(
+                                context,
+                                availableCategories: categoryNames,
+                              ),
+                              icon: const Icon(Icons.add),
+                              label: const Text('Agregar producto'),
+                            ),
+                          ],
+                        ),
                       ),
-                      const Divider(),
-                      ...products.map((product) {
-                        return ListTile(
-                          contentPadding: EdgeInsets.zero,
-                          title: Text(product.name),
-                          subtitle: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Text(product.description?.isNotEmpty == true
-                                  ? product.description!
-                                  : 'Sin descripción'),
-                              const SizedBox(height: 4),
-                              Text(product.isAvailable ? 'Disponible' : 'Agotado'),
-                            ],
-                          ),
-                          trailing: Row(
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              Text(
-                                _currencyFormat.format(product.price),
-                                style: const TextStyle(fontWeight: FontWeight.bold),
-                              ),
-                              IconButton(
-                                icon: const Icon(Icons.edit),
-                                onPressed: () => _openItemForm(context, item: product),
-                              ),
-                            ],
-                          ),
-                        );
-                      }),
-                    ],
-                  ),
-                ),
+                    ),
+                  ],
+                );
+              }
+
+              final grouped = <String, List<MenuItemModel>>{};
+              for (final item in items) {
+                grouped.putIfAbsent(item.category, () => []).add(item);
+              }
+
+              return ListView(
+                padding: const EdgeInsets.all(16),
+                children: [
+                  _buildCategoriesCard(context, categories),
+                  ...grouped.entries.map((entry) {
+                    final category = entry.key;
+                    final products = entry.value;
+                    return Card(
+                      margin: const EdgeInsets.only(bottom: 20),
+                      child: Padding(
+                        padding: const EdgeInsets.all(16),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Row(
+                              children: [
+                                Icon(Icons.local_dining, color: Colors.black87),
+                                const SizedBox(width: 8),
+                                Text(
+                                  category,
+                                  style: Theme.of(context)
+                                      .textTheme
+                                      .titleMedium
+                                      ?.copyWith(
+                                        fontWeight: FontWeight.bold,
+                                      ),
+                                ),
+                                const Spacer(),
+                                IconButton(
+                                  icon: const Icon(Icons.add_circle_outline),
+                                  onPressed: () => _openItemForm(
+                                    context,
+                                    presetCategory: category,
+                                    availableCategories: categoryNames,
+                                  ),
+                                ),
+                              ],
+                            ),
+                            const Divider(),
+                            ...products.map((product) {
+                              return ListTile(
+                                contentPadding: EdgeInsets.zero,
+                                title: Text(product.name),
+                                subtitle: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    Text(product.description?.isNotEmpty == true
+                                        ? product.description!
+                                        : 'Sin descripción'),
+                                    const SizedBox(height: 4),
+                                    Text(
+                                      product.isAvailable
+                                          ? 'Disponible'
+                                          : 'Agotado',
+                                    ),
+                                  ],
+                                ),
+                                trailing: Row(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    Text(
+                                      _currencyFormat.format(product.price),
+                                      style:
+                                          const TextStyle(fontWeight: FontWeight.bold),
+                                    ),
+                                    IconButton(
+                                      icon: const Icon(Icons.edit),
+                                      onPressed: () => _openItemForm(
+                                        context,
+                                        item: product,
+                                        availableCategories: categoryNames,
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              );
+                            }),
+                          ],
+                        ),
+                      ),
+                    );
+                  }).toList(),
+                ],
               );
-            }).toList(),
+            },
           );
         },
       ),
       floatingActionButton: FloatingActionButton.extended(
         backgroundColor: Colors.black,
         foregroundColor: Colors.white,
-        onPressed: () => _openItemForm(context),
+        onPressed: () => _openItemForm(
+          context,
+          availableCategories: _cachedCategories,
+        ),
         icon: const Icon(Icons.add),
         label: const Text('Nuevo producto'),
       ),

--- a/restaurant_app/lib/features/waiter/pending_orders_screen.dart
+++ b/restaurant_app/lib/features/waiter/pending_orders_screen.dart
@@ -1,0 +1,155 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../../models/order.dart';
+import 'cart_screen.dart';
+
+class PendingOrdersScreen extends StatelessWidget {
+  const PendingOrdersScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final currencyFormat = NumberFormat.simpleCurrency(name: 'USD');
+    return Scaffold(
+      body: Container(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [Color(0xFFFFF6CC), Color(0xFFFFE082)],
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+          ),
+        ),
+        child: SafeArea(
+          child: Column(
+            children: [
+              Padding(
+                padding: const EdgeInsets.fromLTRB(20, 20, 20, 12),
+                child: Row(
+                  children: [
+                    const Icon(Icons.receipt_long, size: 32, color: Colors.black),
+                    const SizedBox(width: 12),
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'Pedidos pendientes',
+                          style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                                fontWeight: FontWeight.bold,
+                              ),
+                        ),
+                        const SizedBox(height: 4),
+                        const Text('Gestiona los pedidos que siguen abiertos'),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+              Expanded(
+                child: ClipRRect(
+                  borderRadius: const BorderRadius.only(
+                    topLeft: Radius.circular(24),
+                    topRight: Radius.circular(24),
+                  ),
+                  child: Container(
+                    color: Theme.of(context).scaffoldBackgroundColor,
+                    child: StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+                      stream: FirebaseFirestore.instance
+                          .collection('orders')
+                          .where('status', isEqualTo: 'open')
+                          .orderBy('createdAt', descending: true)
+                          .snapshots(),
+                      builder: (context, snapshot) {
+                        if (snapshot.connectionState == ConnectionState.waiting) {
+                          return const Center(child: CircularProgressIndicator());
+                        }
+                        if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
+                          return const Center(
+                            child: Text('No hay pedidos pendientes.'),
+                          );
+                        }
+                        final orders = snapshot.data!.docs
+                            .map((doc) => OrderModel.fromMap(doc.id, doc.data()))
+                            .toList();
+                        return ListView.builder(
+                          padding: const EdgeInsets.all(20),
+                          itemCount: orders.length,
+                          itemBuilder: (context, index) {
+                            final order = orders[index];
+                            final subtitleParts = <String>[
+                              if (order.tableNumber != null)
+                                'Mesa #${order.tableNumber}'
+                              else
+                                'Pedido online',
+                              'Canal: ${_channelLabel(order.channel)}',
+                              'Creado: ${DateFormat.Hm().format(order.createdAt)}',
+                            ];
+                            return Card(
+                              margin: const EdgeInsets.only(bottom: 16),
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(20),
+                              ),
+                              child: ListTile(
+                                onTap: () {
+                                  Navigator.of(context).push(
+                                    MaterialPageRoute(
+                                      builder: (_) => CartScreen(orderId: order.id),
+                                    ),
+                                  );
+                                },
+                                leading: CircleAvatar(
+                                  backgroundColor: const Color(0xFFFFC107).withOpacity(.18),
+                                  foregroundColor: Colors.black,
+                                  child: Text('#${order.orderNumber}'),
+                                ),
+                                title: Text(
+                                  order.items.isEmpty
+                                      ? 'Pedido sin productos'
+                                      : order.items.first.name,
+                                ),
+                                subtitle: Text(subtitleParts.join(' · ')),
+                                trailing: Column(
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  crossAxisAlignment: CrossAxisAlignment.end,
+                                  children: [
+                                    Text(
+                                      currencyFormat.format(order.total),
+                                      style: const TextStyle(
+                                        fontWeight: FontWeight.bold,
+                                        fontSize: 16,
+                                      ),
+                                    ),
+                                    const SizedBox(height: 4),
+                                    const Text(
+                                      'Ver detalles',
+                                      style: TextStyle(fontSize: 12),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            );
+                          },
+                        );
+                      },
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+String _channelLabel(String channel) {
+  switch (channel) {
+    case 'dine-in':
+      return 'En mesa';
+    case 'online':
+      return 'Online';
+    default:
+      return channel;
+  }
+}

--- a/restaurant_app/lib/features/waiter/table_select_screen.dart
+++ b/restaurant_app/lib/features/waiter/table_select_screen.dart
@@ -2,7 +2,9 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 
 import '../../models/restaurant_table.dart';
+import 'cart_screen.dart';
 import 'menu_screen.dart';
+import 'pending_orders_screen.dart';
 
 class TableSelectScreen extends StatelessWidget {
   const TableSelectScreen({super.key});
@@ -39,6 +41,22 @@ class TableSelectScreen extends StatelessWidget {
                         const SizedBox(height: 4),
                         const Text('Visualiza disponibilidad en tiempo real'),
                       ],
+                    ),
+                    const Spacer(),
+                    FilledButton.icon(
+                      style: FilledButton.styleFrom(
+                        backgroundColor: Colors.black,
+                        foregroundColor: Colors.white,
+                      ),
+                      onPressed: () {
+                        Navigator.of(context).push(
+                          MaterialPageRoute(
+                            builder: (_) => const PendingOrdersScreen(),
+                          ),
+                        );
+                      },
+                      icon: const Icon(Icons.receipt_long),
+                      label: const Text('Pedidos'),
                     ),
                   ],
                 ),
@@ -84,14 +102,25 @@ class TableSelectScreen extends StatelessWidget {
                             return InkWell(
                               borderRadius: BorderRadius.circular(24),
                               onTap: () {
-                                Navigator.of(context).push(
-                                  MaterialPageRoute(
-                                    builder: (_) => MenuScreen(
-                                      tableId: table.id,
-                                      tableNumber: table.number,
+                                if (table.status == 'occupied' &&
+                                    table.currentOrderId != null) {
+                                  Navigator.of(context).push(
+                                    MaterialPageRoute(
+                                      builder: (_) => CartScreen(
+                                        orderId: table.currentOrderId!,
+                                      ),
                                     ),
-                                  ),
-                                );
+                                  );
+                                } else {
+                                  Navigator.of(context).push(
+                                    MaterialPageRoute(
+                                      builder: (_) => MenuScreen(
+                                        tableId: table.id,
+                                        tableNumber: table.number,
+                                      ),
+                                    ),
+                                  );
+                                }
                               },
                               child: Card(
                                 elevation: 6,

--- a/restaurant_app/lib/models/category.dart
+++ b/restaurant_app/lib/models/category.dart
@@ -1,0 +1,24 @@
+class CategoryModel {
+  const CategoryModel({
+    required this.id,
+    required this.name,
+  });
+
+  final String id;
+  final String name;
+
+  factory CategoryModel.fromMap(String id, Map<String, dynamic> data) {
+    return CategoryModel(
+      id: id,
+      name: (data['name'] as String?)?.trim().isNotEmpty == true
+          ? (data['name'] as String).trim()
+          : 'Sin nombre',
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'name': name,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- allow waiters to review active orders, add more products, and close them with payment tracking
- expose pending orders directly from the tables view and reuse existing table occupancy when reopening carts
- introduce menu categories support with Firestore persistence and selection helpers in the admin catalog

## Testing
- unable to run `flutter format` (command not found in container)


------
https://chatgpt.com/codex/tasks/task_e_68e1934cb8f08320accd457e40f051fd