### PR TITLE
Fix report date picker and enable expense editing

### DIFF
--- a/restaurant_app/lib/features/admin/reports_screen.dart
+++ b/restaurant_app/lib/features/admin/reports_screen.dart
@@ -141,7 +141,7 @@ class _ReportsScreenState extends State<ReportsScreen> {
                   onPressed: _pickRange,
                   icon: const Icon(Icons.calendar_month),
                   label: Text(
-                    '${DateFormat('dd/MM/yyyy').format(_range.start)} - ${DateFormat('dd/MM/yyyy').format(_range.end)}',
+                    '${DateFormat('dd/MM/yyyy', 'es').format(_range.start)} - ${DateFormat('dd/MM/yyyy', 'es').format(_range.end)}',
                   ),
                 ),
                 FilledButton.icon(

--- a/restaurant_app/lib/main.dart
+++ b/restaurant_app/lib/main.dart
@@ -1,12 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:intl/date_symbol_data_local.dart';
+
 import 'firebase_options.dart'; // generado por flutterfire configure
 import 'app_router.dart';
 
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await initializeDateFormatting('es');
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
   runApp(const ProviderScope(child: RestaurantApp()));
 }
@@ -32,6 +36,16 @@ class RestaurantApp extends ConsumerWidget {
     return MaterialApp.router(
       title: 'Golden Burger',
       routerConfig: router,
+      locale: const Locale('es'),
+      supportedLocales: const [
+        Locale('es'),
+        Locale('en'),
+      ],
+      localizationsDelegates: const [
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
       theme: ThemeData(
         useMaterial3: true,
         colorScheme: colorScheme,

--- a/restaurant_app/lib/repositories/expense_repository.dart
+++ b/restaurant_app/lib/repositories/expense_repository.dart
@@ -14,27 +14,76 @@ class ExpenseRepository {
       'createdAt': FieldValue.serverTimestamp(),
     });
 
-    final now = Timestamp.now().toDate();
-    final dayId =
-        '${now.year.toString().padLeft(4, '0')}-${now.month.toString().padLeft(2, '0')}-${now.day.toString().padLeft(2, '0')}';
-    final monthId =
-        '${now.year.toString().padLeft(4, '0')}-${now.month.toString().padLeft(2, '0')}';
+    await _updateSummariesWithDelta(expense.date, expense.amount);
+  }
+
+  Future<void> updateExpense({
+    required Expense original,
+    required Expense updated,
+  }) async {
+    final docRef = _db.collection('expenses').doc(original.id);
+
+    await _db.runTransaction((trx) async {
+      trx.update(docRef, updated.toMap());
+
+      final originalDay = _formatDay(original.date);
+      final updatedDay = _formatDay(updated.date);
+
+      if (originalDay == updatedDay) {
+        final diff = updated.amount - original.amount;
+        if (diff != 0) {
+          _applySummaryDelta(trx, updated.date, diff);
+        }
+      } else {
+        _applySummaryDelta(trx, original.date, -original.amount);
+        _applySummaryDelta(trx, updated.date, updated.amount);
+      }
+    });
+  }
+
+  Future<void> deleteExpense(Expense expense) async {
+    final docRef = _db.collection('expenses').doc(expense.id);
+
+    await _db.runTransaction((trx) async {
+      trx.delete(docRef);
+      _applySummaryDelta(trx, expense.date, -expense.amount);
+    });
+  }
+
+  Future<void> _updateSummariesWithDelta(DateTime date, double amountDelta) async {
+    if (amountDelta == 0) return;
+    await _db.runTransaction((trx) async {
+      _applySummaryDelta(trx, date, amountDelta);
+    });
+  }
+
+  void _applySummaryDelta(Transaction trx, DateTime date, double amountDelta) {
+    if (amountDelta == 0) return;
+    final normalized = DateTime(date.year, date.month, date.day);
+    final dayId = _formatDay(normalized);
+    final monthId = _formatMonth(normalized);
     final dailyRef =
         _db.collection('summaries').doc('daily').collection('docs').doc(dayId);
     final monthlyRef =
         _db.collection('summaries').doc('monthly').collection('docs').doc(monthId);
 
-    await _db.runTransaction((trx) async {
-      trx.set(
-        dailyRef,
-        {'expensesTotal': FieldValue.increment(expense.amount)},
-        SetOptions(merge: true),
-      );
-      trx.set(
-        monthlyRef,
-        {'expensesTotal': FieldValue.increment(expense.amount)},
-        SetOptions(merge: true),
-      );
-    });
+    trx.set(
+      dailyRef,
+      {'expensesTotal': FieldValue.increment(amountDelta)},
+      SetOptions(merge: true),
+    );
+    trx.set(
+      monthlyRef,
+      {'expensesTotal': FieldValue.increment(amountDelta)},
+      SetOptions(merge: true),
+    );
+  }
+
+  String _formatDay(DateTime date) {
+    return '${date.year.toString().padLeft(4, '0')}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}';
+  }
+
+  String _formatMonth(DateTime date) {
+    return '${date.year.toString().padLeft(4, '0')}-${date.month.toString().padLeft(2, '0')}';
   }
 }

--- a/restaurant_app/pubspec.lock
+++ b/restaurant_app/pubspec.lock
@@ -158,6 +158,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_localizations:
+    dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/restaurant_app/pubspec.yaml
+++ b/restaurant_app/pubspec.yaml
@@ -30,6 +30,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
 
 
   # The following adds the Cupertino Icons font to your application.


### PR DESCRIPTION
## Summary
- add Flutter localization support and initialize Spanish date symbols to allow the report date picker to open without errors
- localize report date range labels and enhance the expense form to support editing, canceling, and deleting existing records
- update the expense repository logic so edits and deletions keep daily and monthly summaries consistent

## Testing
- Not run (Flutter SDK is not available in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68e19bc7c330832098a65ccb4324b5eb