### PR TITLE
Mejorar experiencia responsiva en la app de meseros

### DIFF
--- a/restaurant_app/lib/features/waiter/cart_screen.dart
+++ b/restaurant_app/lib/features/waiter/cart_screen.dart
@@ -14,6 +14,9 @@ class CartScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final currencyFormat = NumberFormat.simpleCurrency(name: 'USD');
+    final size = MediaQuery.of(context).size;
+    final isCompact = size.width < 600;
+    final horizontalPadding = isCompact ? 16.0 : 24.0;
     return Scaffold(
       appBar: AppBar(
         title: StreamBuilder<DocumentSnapshot<Map<String, dynamic>>>(
@@ -102,115 +105,199 @@ class CartScreen extends StatelessWidget {
             }
 
             return SafeArea(
-              child: Column(
-                children: [
-                  Padding(
-                    padding: const EdgeInsets.all(20),
-                    child: Card(
-                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
-                      child: Padding(
-                        padding: const EdgeInsets.all(16),
-                        child: Row(
-                          children: [
-                            const Icon(Icons.receipt_long, size: 32),
-                            const SizedBox(width: 12),
-                            Expanded(
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  Text(
-                                    'Resumen del pedido',
-                                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                                          fontWeight: FontWeight.bold,
-                                        ),
-                                  ),
-                                  const SizedBox(height: 4),
-                                  Text(
-                                  [
-                                    if (tableNumber != null) 'Mesa #$tableNumber',
-                                    'Canal: ${_channelLabel(channel)}',
-                                    'Estado: ${_statusLabel(status)}',
-                                    if (paymentMethod != null)
-                                      'Pago: ${_paymentMethodLabel(paymentMethod)}',
-                                  ].join(' · '),
-                                ),
-                              ],
-                            ),
-                            ),
-                            Chip(
-                              backgroundColor: Colors.black,
-                              labelStyle: const TextStyle(color: Colors.white),
-                              label: Text(currencyFormat.format(total)),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ),
-                  ),
-                  Expanded(
-                    child: items.isEmpty
-                        ? const Center(
-                            child: Text('Aún no hay productos en este pedido.'),
-                          )
-                        : ListView.builder(
-                            padding: const EdgeInsets.symmetric(horizontal: 20),
-                            itemCount: items.length,
-                            itemBuilder: (context, index) {
-                              final item = items[index];
-                              final qty = (item['qty'] as num).toInt();
-                              final unit = (item['unitPrice'] as num).toDouble();
-                              final subtotal = (item['subtotal'] as num).toDouble();
-                              return Card(
-                                margin: const EdgeInsets.only(bottom: 16),
-                                shape: RoundedRectangleBorder(
-                                    borderRadius: BorderRadius.circular(18)),
-                                child: ListTile(
-                                  leading: CircleAvatar(
-                                    backgroundColor:
-                                        const Color(0xFFFFC107).withOpacity(.2),
-                                    child: Text('${index + 1}'),
-                                  ),
-                                  title: Text(item['name'] as String? ?? 'Producto'),
-                                  subtitle:
-                                      Text('$qty × ${currencyFormat.format(unit)}'),
-                                  trailing: Text(
-                                    currencyFormat.format(subtotal),
-                                    style:
-                                        const TextStyle(fontWeight: FontWeight.bold),
-                                  ),
-                                ),
-                              );
-                            },
-                          ),
-                  ),
-                  if (status == 'open')
-                    Padding(
-                      padding: const EdgeInsets.fromLTRB(20, 0, 20, 20),
-                      child: Row(
+              child: LayoutBuilder(
+                builder: (context, constraints) {
+                  return Center(
+                    child: ConstrainedBox(
+                      constraints: const BoxConstraints(maxWidth: 900),
+                      child: Column(
                         children: [
-                          Expanded(
-                            child: OutlinedButton.icon(
-                              onPressed: addMoreItems,
-                              icon: const Icon(Icons.playlist_add),
-                              label: const Text('Agregar productos'),
-                            ),
-                          ),
-                          const SizedBox(width: 12),
-                          Expanded(
-                            child: FilledButton.icon(
-                              onPressed: finalizeOrder,
-                              icon: const Icon(Icons.check_circle_outline),
-                              label: const Text('Finalizar pedido'),
-                              style: FilledButton.styleFrom(
-                                backgroundColor: Colors.black,
-                                foregroundColor: Colors.white,
+                          Padding(
+                            padding: EdgeInsets.all(horizontalPadding),
+                            child: Card(
+                              shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(20)),
+                              child: Padding(
+                                padding: const EdgeInsets.all(16),
+                                child: LayoutBuilder(
+                                  builder: (context, contentConstraints) {
+                                    final compactHeader = contentConstraints.maxWidth < 500;
+                                    final detailsText = [
+                                      if (tableNumber != null) 'Mesa #$tableNumber',
+                                      'Canal: ${_channelLabel(channel)}',
+                                      'Estado: ${_statusLabel(status)}',
+                                      if (paymentMethod != null)
+                                        'Pago: ${_paymentMethodLabel(paymentMethod)}',
+                                    ].join(' · ');
+                                    final chip = Chip(
+                                      backgroundColor: Colors.black,
+                                      labelStyle: const TextStyle(color: Colors.white),
+                                      label: Text(currencyFormat.format(total)),
+                                    );
+                                    return compactHeader
+                                        ? Column(
+                                            crossAxisAlignment: CrossAxisAlignment.start,
+                                            children: [
+                                              Row(
+                                                crossAxisAlignment: CrossAxisAlignment.start,
+                                                children: [
+                                                  const Icon(Icons.receipt_long, size: 32),
+                                                  const SizedBox(width: 12),
+                                                  Expanded(
+                                                    child: Column(
+                                                      crossAxisAlignment:
+                                                          CrossAxisAlignment.start,
+                                                      children: [
+                                                        Text(
+                                                          'Resumen del pedido',
+                                                          style: Theme.of(context)
+                                                              .textTheme
+                                                              .titleMedium
+                                                              ?.copyWith(
+                                                                  fontWeight:
+                                                                      FontWeight.bold),
+                                                        ),
+                                                        const SizedBox(height: 4),
+                                                        Text(detailsText),
+                                                      ],
+                                                    ),
+                                                  ),
+                                                ],
+                                              ),
+                                              const SizedBox(height: 12),
+                                              chip,
+                                            ],
+                                          )
+                                        : Row(
+                                            children: [
+                                              const Icon(Icons.receipt_long, size: 32),
+                                              const SizedBox(width: 12),
+                                              Expanded(
+                                                child: Column(
+                                                  crossAxisAlignment:
+                                                      CrossAxisAlignment.start,
+                                                  children: [
+                                                    Text(
+                                                      'Resumen del pedido',
+                                                      style: Theme.of(context)
+                                                          .textTheme
+                                                          .titleMedium
+                                                          ?.copyWith(
+                                                              fontWeight:
+                                                                  FontWeight.bold),
+                                                    ),
+                                                    const SizedBox(height: 4),
+                                                    Text(detailsText),
+                                                  ],
+                                                ),
+                                              ),
+                                              chip,
+                                            ],
+                                          );
+                                  },
+                                ),
                               ),
                             ),
                           ),
+                          Expanded(
+                            child: items.isEmpty
+                                ? const Center(
+                                    child: Text('Aún no hay productos en este pedido.'),
+                                  )
+                                : ListView.builder(
+                                    padding: EdgeInsets.symmetric(
+                                      horizontal: horizontalPadding,
+                                    ),
+                                    itemCount: items.length,
+                                    itemBuilder: (context, index) {
+                                      final item = items[index];
+                                      final qty = (item['qty'] as num).toInt();
+                                      final unit = (item['unitPrice'] as num).toDouble();
+                                      final subtotal =
+                                          (item['subtotal'] as num).toDouble();
+                                      return Card(
+                                        margin: const EdgeInsets.only(bottom: 16),
+                                        shape: RoundedRectangleBorder(
+                                            borderRadius: BorderRadius.circular(18)),
+                                        child: ListTile(
+                                          leading: CircleAvatar(
+                                            backgroundColor: const Color(0xFFFFC107)
+                                                .withOpacity(.2),
+                                            child: Text('${index + 1}'),
+                                          ),
+                                          title: Text(
+                                              item['name'] as String? ?? 'Producto'),
+                                          subtitle: Text(
+                                              '$qty × ${currencyFormat.format(unit)}'),
+                                          trailing: Text(
+                                            currencyFormat.format(subtotal),
+                                            style: const TextStyle(
+                                                fontWeight: FontWeight.bold),
+                                          ),
+                                        ),
+                                      );
+                                    },
+                                  ),
+                          ),
+                          if (status == 'open')
+                            Padding(
+                              padding: EdgeInsets.fromLTRB(
+                                horizontalPadding,
+                                0,
+                                horizontalPadding,
+                                isCompact ? 16 : 20,
+                              ),
+                              child: isCompact
+                                  ? Column(
+                                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                                      children: [
+                                        OutlinedButton.icon(
+                                          onPressed: addMoreItems,
+                                          icon: const Icon(Icons.playlist_add),
+                                          label: const Text('Agregar productos'),
+                                        ),
+                                        const SizedBox(height: 12),
+                                        FilledButton.icon(
+                                          onPressed: finalizeOrder,
+                                          icon: const Icon(Icons.check_circle_outline),
+                                          label: const Text('Finalizar pedido'),
+                                          style: FilledButton.styleFrom(
+                                            backgroundColor: Colors.black,
+                                            foregroundColor: Colors.white,
+                                          ),
+                                        ),
+                                      ],
+                                    )
+                                  : Row(
+                                      children: [
+                                        Expanded(
+                                          child: OutlinedButton.icon(
+                                            onPressed: addMoreItems,
+                                            icon: const Icon(Icons.playlist_add),
+                                            label: const Text('Agregar productos'),
+                                          ),
+                                        ),
+                                        const SizedBox(width: 12),
+                                        Expanded(
+                                          child: FilledButton.icon(
+                                            onPressed: finalizeOrder,
+                                            icon:
+                                                const Icon(Icons.check_circle_outline),
+                                            label: const Text('Finalizar pedido'),
+                                            style: FilledButton.styleFrom(
+                                              backgroundColor: Colors.black,
+                                              foregroundColor: Colors.white,
+                                            ),
+                                          ),
+                                        ),
+                                      ],
+                                    ),
+                            ),
                         ],
                       ),
                     ),
-                ],
+                  );
+                },
               ),
             );
           },

--- a/restaurant_app/lib/features/waiter/menu_screen.dart
+++ b/restaurant_app/lib/features/waiter/menu_screen.dart
@@ -149,6 +149,10 @@ class _MenuScreenState extends State<MenuScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final size = MediaQuery.of(context).size;
+    final isCompact = size.width < 600;
+    final horizontalPadding = isCompact ? 16.0 : 24.0;
+    final topPadding = isCompact ? 12.0 : 16.0;
     final title = _isEditingOrder
         ? 'Agregar productos'
         : widget.tableId == null
@@ -164,93 +168,121 @@ class _MenuScreenState extends State<MenuScreen> {
           ),
         ),
         child: SafeArea(
-          child: Column(
-            children: [
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
-                child: Row(
-                  children: [
-                    const Icon(Icons.lunch_dining, size: 32, color: Colors.black),
-                    const SizedBox(width: 12),
-                    Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          title,
-                          style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                                fontWeight: FontWeight.bold,
-                              ),
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              return Center(
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 1000),
+                  child: Column(
+                    children: [
+                      Padding(
+                        padding: EdgeInsets.fromLTRB(
+                          horizontalPadding,
+                          topPadding,
+                          horizontalPadding,
+                          topPadding,
                         ),
-                        const SizedBox(height: 4),
-                        const Text('Elige tus favoritos de Ing Burger'),
-                      ],
-                    ),
-                  ],
-                ),
-              ),
-              Expanded(
-                child: ClipRRect(
-                  borderRadius: const BorderRadius.only(
-                    topLeft: Radius.circular(24),
-                    topRight: Radius.circular(24),
-                  ),
-                  child: Container(
-                    color: Theme.of(context).scaffoldBackgroundColor,
-                    child: StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
-                      stream: FirebaseFirestore.instance
-                          .collection('menu_items')
-                          .where('isAvailable', isEqualTo: true)
-                          .snapshots(),
-                      builder: (context, snapshot) {
-                        if (!snapshot.hasData) {
-                          return const Center(child: CircularProgressIndicator());
-                        }
-                        final items = snapshot.data!.docs
-                            .map((doc) => MenuItemModel.fromMap(doc.id, doc.data()))
-                            .toList();
-                        if (items.isEmpty) {
-                          return const Center(
-                            child: Text('No hay elementos disponibles por ahora.'),
-                          );
-                        }
-                        final grouped = <String, List<MenuItemModel>>{};
-                        for (final item in items) {
-                          grouped.putIfAbsent(item.category, () => []).add(item);
-                        }
-                        return ListView(
-                          padding: const EdgeInsets.all(20),
-                          children: grouped.entries.map((entry) {
-                            final category = entry.key;
-                            final categoryItems = entry.value;
-                            return Column(
+                        child: Wrap(
+                          spacing: 12,
+                          runSpacing: 12,
+                          crossAxisAlignment: WrapCrossAlignment.center,
+                          children: [
+                            const Icon(Icons.lunch_dining, size: 32, color: Colors.black),
+                            Column(
                               crossAxisAlignment: CrossAxisAlignment.start,
                               children: [
                                 Text(
-                                  category,
-                                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                                  title,
+                                  style: Theme.of(context).textTheme.titleLarge?.copyWith(
                                         fontWeight: FontWeight.bold,
                                       ),
                                 ),
-                                const SizedBox(height: 12),
-                                ...categoryItems.map(
-                                  (item) => _MenuCard(
-                                    item: item,
-                                    currencyFormat: _currencyFormat,
-                                    onAdd: () => _addToCart(item),
-                                  ),
-                                ),
-                                const SizedBox(height: 24),
+                                const SizedBox(height: 4),
+                                const Text('Elige tus favoritos de Ing Burger'),
                               ],
-                            );
-                          }).toList(),
-                        );
-                      },
-                    ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      Expanded(
+                        child: ClipRRect(
+                          borderRadius: const BorderRadius.only(
+                            topLeft: Radius.circular(24),
+                            topRight: Radius.circular(24),
+                          ),
+                          child: Container(
+                            color: Theme.of(context).scaffoldBackgroundColor,
+                            child: StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+                              stream: FirebaseFirestore.instance
+                                  .collection('menu_items')
+                                  .where('isAvailable', isEqualTo: true)
+                                  .snapshots(),
+                              builder: (context, snapshot) {
+                                if (!snapshot.hasData) {
+                                  return const Center(child: CircularProgressIndicator());
+                                }
+                                final items = snapshot.data!.docs
+                                    .map((doc) => MenuItemModel.fromMap(doc.id, doc.data()))
+                                    .toList();
+                                if (items.isEmpty) {
+                                  return const Center(
+                                    child: Text('No hay elementos disponibles por ahora.'),
+                                  );
+                                }
+                                final grouped = <String, List<MenuItemModel>>{};
+                                for (final item in items) {
+                                  grouped.putIfAbsent(item.category, () => []).add(item);
+                                }
+                                return ListView(
+                                  padding: EdgeInsets.fromLTRB(
+                                    horizontalPadding,
+                                    20,
+                                    horizontalPadding,
+                                    20,
+                                  ),
+                                  children: grouped.entries.map((entry) {
+                                    final category = entry.key;
+                                    final categoryItems = entry.value;
+                                    return Column(
+                                      crossAxisAlignment: CrossAxisAlignment.start,
+                                      children: [
+                                        Text(
+                                          category,
+                                          style:
+                                              Theme.of(context).textTheme.titleMedium?.copyWith(
+                                                    fontWeight: FontWeight.bold,
+                                                  ),
+                                        ),
+                                        const SizedBox(height: 12),
+                                        ...categoryItems.map(
+                                          (item) => _MenuCard(
+                                            item: item,
+                                            currencyFormat: _currencyFormat,
+                                            onAdd: () => _addToCart(item),
+                                          ),
+                                        ),
+                                        const SizedBox(height: 24),
+                                      ],
+                                    );
+                                  }).toList(),
+                                );
+                              },
+                            ),
+                          ),
+                        ),
+                      ),
+                      if (_cart.isNotEmpty)
+                        Padding(
+                          padding: EdgeInsets.symmetric(
+                            horizontal: horizontalPadding,
+                          ),
+                          child: _buildCartSummary(),
+                        ),
+                    ],
                   ),
                 ),
-              ),
-              if (_cart.isNotEmpty) _buildCartSummary(),
-            ],
+              );
+            },
           ),
         ),
       ),
@@ -284,7 +316,7 @@ class _MenuScreenState extends State<MenuScreen> {
 
   Widget _buildCartSummary() {
     return Card(
-      margin: const EdgeInsets.fromLTRB(20, 0, 20, 20),
+      margin: const EdgeInsets.only(bottom: 20),
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
       child: Padding(
         padding: const EdgeInsets.all(16),
@@ -364,64 +396,91 @@ class _MenuCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Card(
-      margin: const EdgeInsets.only(bottom: 12),
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            CircleAvatar(
-              radius: 28,
-              backgroundColor: const Color(0xFFFFC107).withOpacity(.2),
-              child: Text(
-                item.name.isNotEmpty ? item.name[0].toUpperCase() : '🍔',
-                style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 20),
-              ),
-            ),
-            const SizedBox(width: 16),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    item.name,
-                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                          fontWeight: FontWeight.bold,
-                        ),
-                  ),
-                  const SizedBox(height: 4),
-                  Text(
-                    item.description?.isNotEmpty == true
-                        ? item.description!
-                        : 'Perfecto para compartir y disfrutar.',
-                    style: Theme.of(context).textTheme.bodySmall,
-                  ),
-                  const SizedBox(height: 8),
-                  Text(
-                    currencyFormat.format(item.price),
-                    style: const TextStyle(
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final isCompact = constraints.maxWidth < 520;
+        final avatar = CircleAvatar(
+          radius: 28,
+          backgroundColor: const Color(0xFFFFC107).withOpacity(.2),
+          child: Text(
+            item.name.isNotEmpty ? item.name[0].toUpperCase() : '🍔',
+            style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 20),
+          ),
+        );
+        final description = Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                item.name,
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
                       fontWeight: FontWeight.bold,
-                      fontSize: 16,
                     ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                item.description?.isNotEmpty == true
+                    ? item.description!
+                    : 'Perfecto para compartir y disfrutar.',
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                currencyFormat.format(item.price),
+                style: const TextStyle(
+                  fontWeight: FontWeight.bold,
+                  fontSize: 16,
+                ),
+              ),
+            ],
+          ),
+        );
+        final button = FilledButton(
+          onPressed: onAdd,
+          style: FilledButton.styleFrom(
+            backgroundColor: Colors.black,
+            foregroundColor: Colors.white,
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          ),
+          child: const Text('Agregar'),
+        );
+        return Card(
+          margin: const EdgeInsets.only(bottom: 12),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: isCompact
+                ? Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          avatar,
+                          const SizedBox(width: 16),
+                          description,
+                        ],
+                      ),
+                      const SizedBox(height: 16),
+                      SizedBox(
+                        width: double.infinity,
+                        child: button,
+                      ),
+                    ],
+                  )
+                : Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      avatar,
+                      const SizedBox(width: 16),
+                      description,
+                      const SizedBox(width: 12),
+                      button,
+                    ],
                   ),
-                ],
-              ),
-            ),
-            const SizedBox(width: 12),
-            FilledButton(
-              onPressed: onAdd,
-              style: FilledButton.styleFrom(
-                backgroundColor: Colors.black,
-                foregroundColor: Colors.white,
-                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-              ),
-              child: const Text('Agregar'),
-            ),
-          ],
-        ),
-      ),
+          ),
+        );
+      },
     );
   }
 }

--- a/restaurant_app/lib/features/waiter/pending_orders_screen.dart
+++ b/restaurant_app/lib/features/waiter/pending_orders_screen.dart
@@ -11,6 +11,10 @@ class PendingOrdersScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final currencyFormat = NumberFormat.simpleCurrency(name: 'USD');
+    final size = MediaQuery.of(context).size;
+    final isCompact = size.width < 600;
+    final horizontalPadding = isCompact ? 16.0 : 24.0;
+    final topPadding = isCompact ? 16.0 : 20.0;
     return Scaffold(
       body: Container(
         decoration: const BoxDecoration(
@@ -21,63 +25,81 @@ class PendingOrdersScreen extends StatelessWidget {
           ),
         ),
         child: SafeArea(
-          child: Column(
-            children: [
-              Padding(
-                padding: const EdgeInsets.fromLTRB(20, 20, 20, 12),
-                child: Row(
-                  children: [
-                    const Icon(Icons.receipt_long, size: 32, color: Colors.black),
-                    const SizedBox(width: 12),
-                    Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          'Pedidos pendientes',
-                          style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                                fontWeight: FontWeight.bold,
-                              ),
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              return Center(
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 900),
+                  child: Column(
+                    children: [
+                      Padding(
+                        padding: EdgeInsets.fromLTRB(
+                          horizontalPadding,
+                          topPadding,
+                          horizontalPadding,
+                          isCompact ? 8 : 12,
                         ),
-                        const SizedBox(height: 4),
-                        const Text('Gestiona los pedidos que siguen abiertos'),
-                      ],
-                    ),
-                  ],
-                ),
-              ),
-              Expanded(
-                child: ClipRRect(
-                  borderRadius: const BorderRadius.only(
-                    topLeft: Radius.circular(24),
-                    topRight: Radius.circular(24),
-                  ),
-                  child: Container(
-                    color: Theme.of(context).scaffoldBackgroundColor,
-                    child: StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
-                      stream: FirebaseFirestore.instance
-                          .collection('orders')
-                          .where('status', isEqualTo: 'open')
-                          .orderBy('createdAt', descending: true)
-                          .snapshots(),
-                      builder: (context, snapshot) {
-                        if (snapshot.connectionState == ConnectionState.waiting) {
-                          return const Center(child: CircularProgressIndicator());
-                        }
-                        if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
-                          return const Center(
-                            child: Text('No hay pedidos pendientes.'),
-                          );
-                        }
-                        final orders = snapshot.data!.docs
-                            .map((doc) => OrderModel.fromMap(doc.id, doc.data()))
-                            .toList();
-                        return ListView.builder(
-                          padding: const EdgeInsets.all(20),
-                          itemCount: orders.length,
-                          itemBuilder: (context, index) {
-                            final order = orders[index];
-                            final subtitleParts = <String>[
-                              if (order.tableNumber != null)
+                        child: Row(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            const Icon(Icons.receipt_long, size: 32, color: Colors.black),
+                            const SizedBox(width: 12),
+                            Expanded(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Text(
+                                    'Pedidos pendientes',
+                                    style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                                          fontWeight: FontWeight.bold,
+                                        ),
+                                  ),
+                                  const SizedBox(height: 4),
+                                  const Text('Gestiona los pedidos que siguen abiertos'),
+                                ],
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      Expanded(
+                        child: ClipRRect(
+                          borderRadius: const BorderRadius.only(
+                            topLeft: Radius.circular(24),
+                            topRight: Radius.circular(24),
+                          ),
+                          child: Container(
+                            color: Theme.of(context).scaffoldBackgroundColor,
+                            child: StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+                              stream: FirebaseFirestore.instance
+                                  .collection('orders')
+                                  .where('status', isEqualTo: 'open')
+                                  .orderBy('createdAt', descending: true)
+                                  .snapshots(),
+                              builder: (context, snapshot) {
+                                if (snapshot.connectionState == ConnectionState.waiting) {
+                                  return const Center(child: CircularProgressIndicator());
+                                }
+                                if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
+                                  return const Center(
+                                    child: Text('No hay pedidos pendientes.'),
+                                  );
+                                }
+                                final orders = snapshot.data!.docs
+                                    .map((doc) => OrderModel.fromMap(doc.id, doc.data()))
+                                    .toList();
+                                return ListView.builder(
+                                  padding: EdgeInsets.fromLTRB(
+                                    horizontalPadding,
+                                    20,
+                                    horizontalPadding,
+                                    20,
+                                  ),
+                                  itemCount: orders.length,
+                                  itemBuilder: (context, index) {
+                                    final order = orders[index];
+                                    final subtitleParts = <String>[
+                                      if (order.tableNumber != null)
                                 'Mesa #${order.tableNumber}'
                               else
                                 'Pedido online',
@@ -127,15 +149,18 @@ class PendingOrdersScreen extends StatelessWidget {
                                   ],
                                 ),
                               ),
-                            );
-                          },
-                        );
-                      },
-                    ),
+                                  );
+                                },
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
                   ),
                 ),
-              ),
-            ],
+              );
+            },
           ),
         ),
       ),

--- a/restaurant_app/lib/features/waiter/table_select_screen.dart
+++ b/restaurant_app/lib/features/waiter/table_select_screen.dart
@@ -11,6 +11,10 @@ class TableSelectScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final size = MediaQuery.of(context).size;
+    final isCompact = size.width < 600;
+    final horizontalPadding = isCompact ? 16.0 : 24.0;
+    final topPadding = isCompact ? 16.0 : 20.0;
     return Scaffold(
       body: Container(
         decoration: const BoxDecoration(
@@ -21,86 +25,160 @@ class TableSelectScreen extends StatelessWidget {
           ),
         ),
         child: SafeArea(
-          child: Column(
-            children: [
-              Padding(
-                padding: const EdgeInsets.fromLTRB(20, 20, 20, 12),
-                child: Row(
-                  children: [
-                    const Icon(Icons.table_bar, size: 32, color: Colors.black),
-                    const SizedBox(width: 12),
-                    Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          'Selecciona una mesa',
-                          style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                                fontWeight: FontWeight.bold,
-                              ),
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              final maxWidth = constraints.maxWidth;
+              final isHeaderCompact = maxWidth < 720;
+              final gridPadding = EdgeInsets.all(isCompact ? 16 : 24);
+              final crossAxisCount = maxWidth >= 1200
+                  ? 4
+                  : maxWidth >= 900
+                      ? 3
+                      : maxWidth >= 600
+                          ? 2
+                          : 1;
+              final childAspectRatio = maxWidth >= 1200
+                  ? 1.4
+                  : maxWidth >= 900
+                      ? 1.25
+                      : maxWidth >= 600
+                          ? 1.15
+                          : 1.05;
+              return Center(
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 1100),
+                  child: Column(
+                    children: [
+                      Padding(
+                        padding: EdgeInsets.fromLTRB(
+                          horizontalPadding,
+                          topPadding,
+                          horizontalPadding,
+                          isCompact ? 8 : 12,
                         ),
-                        const SizedBox(height: 4),
-                        const Text('Visualiza disponibilidad en tiempo real'),
-                      ],
-                    ),
-                    const Spacer(),
-                    FilledButton.icon(
-                      style: FilledButton.styleFrom(
-                        backgroundColor: Colors.black,
-                        foregroundColor: Colors.white,
+                        child: isHeaderCompact
+                            ? Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Row(
+                                    children: [
+                                      const Icon(Icons.table_bar, size: 32, color: Colors.black),
+                                      const SizedBox(width: 12),
+                                      Expanded(
+                                        child: Column(
+                                          crossAxisAlignment: CrossAxisAlignment.start,
+                                          children: [
+                                            Text(
+                                              'Selecciona una mesa',
+                                              style: Theme.of(context)
+                                                  .textTheme
+                                                  .titleLarge
+                                                  ?.copyWith(fontWeight: FontWeight.bold),
+                                            ),
+                                            const SizedBox(height: 4),
+                                            const Text('Visualiza disponibilidad en tiempo real'),
+                                          ],
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                  const SizedBox(height: 12),
+                                  SizedBox(
+                                    width: double.infinity,
+                                    child: FilledButton.icon(
+                                      style: FilledButton.styleFrom(
+                                        backgroundColor: Colors.black,
+                                        foregroundColor: Colors.white,
+                                      ),
+                                      onPressed: () {
+                                        Navigator.of(context).push(
+                                          MaterialPageRoute(
+                                            builder: (_) => const PendingOrdersScreen(),
+                                          ),
+                                        );
+                                      },
+                                      icon: const Icon(Icons.receipt_long),
+                                      label: const Text('Pedidos'),
+                                    ),
+                                  ),
+                                ],
+                              )
+                            : Row(
+                                children: [
+                                  const Icon(Icons.table_bar, size: 32, color: Colors.black),
+                                  const SizedBox(width: 12),
+                                  Column(
+                                    crossAxisAlignment: CrossAxisAlignment.start,
+                                    children: [
+                                      Text(
+                                        'Selecciona una mesa',
+                                        style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                                              fontWeight: FontWeight.bold,
+                                            ),
+                                      ),
+                                      const SizedBox(height: 4),
+                                      const Text('Visualiza disponibilidad en tiempo real'),
+                                    ],
+                                  ),
+                                  const Spacer(),
+                                  FilledButton.icon(
+                                    style: FilledButton.styleFrom(
+                                      backgroundColor: Colors.black,
+                                      foregroundColor: Colors.white,
+                                    ),
+                                    onPressed: () {
+                                      Navigator.of(context).push(
+                                        MaterialPageRoute(
+                                          builder: (_) => const PendingOrdersScreen(),
+                                        ),
+                                      );
+                                    },
+                                    icon: const Icon(Icons.receipt_long),
+                                    label: const Text('Pedidos'),
+                                  ),
+                                ],
+                              ),
                       ),
-                      onPressed: () {
-                        Navigator.of(context).push(
-                          MaterialPageRoute(
-                            builder: (_) => const PendingOrdersScreen(),
+                      Expanded(
+                        child: ClipRRect(
+                          borderRadius: const BorderRadius.only(
+                            topLeft: Radius.circular(28),
+                            topRight: Radius.circular(28),
                           ),
-                        );
-                      },
-                      icon: const Icon(Icons.receipt_long),
-                      label: const Text('Pedidos'),
-                    ),
-                  ],
-                ),
-              ),
-              Expanded(
-                child: ClipRRect(
-                  borderRadius: const BorderRadius.only(
-                    topLeft: Radius.circular(28),
-                    topRight: Radius.circular(28),
-                  ),
-                  child: Container(
-                    color: Theme.of(context).scaffoldBackgroundColor,
-                    child: StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
-                      stream: FirebaseFirestore.instance
-                          .collection('tables')
-                          .orderBy('number')
-                          .snapshots(),
-                      builder: (context, snapshot) {
-                        if (!snapshot.hasData) {
-                          return const Center(child: CircularProgressIndicator());
-                        }
-                        final tables = snapshot.data!.docs
-                            .map((doc) => RestaurantTable.fromMap(doc.id, doc.data()))
-                            .toList();
-                        if (tables.isEmpty) {
-                          return const Center(
-                            child: Text('Aún no hay mesas registradas.'),
-                          );
-                        }
-                        return GridView.builder(
-                          padding: const EdgeInsets.all(20),
-                          gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                            crossAxisCount: 2,
-                            childAspectRatio: 1.2,
-                            mainAxisSpacing: 20,
-                            crossAxisSpacing: 20,
-                          ),
-                          itemCount: tables.length,
-                          itemBuilder: (context, index) {
-                            final table = tables[index];
-                            final status = _statusLabel(table.status);
-                            final color = _statusColor(table.status);
-                            return InkWell(
-                              borderRadius: BorderRadius.circular(24),
+                          child: Container(
+                            color: Theme.of(context).scaffoldBackgroundColor,
+                            child: StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+                              stream: FirebaseFirestore.instance
+                                  .collection('tables')
+                                  .orderBy('number')
+                                  .snapshots(),
+                              builder: (context, snapshot) {
+                                if (!snapshot.hasData) {
+                                  return const Center(child: CircularProgressIndicator());
+                                }
+                                final tables = snapshot.data!.docs
+                                    .map((doc) => RestaurantTable.fromMap(doc.id, doc.data()))
+                                    .toList();
+                                if (tables.isEmpty) {
+                                  return const Center(
+                                    child: Text('Aún no hay mesas registradas.'),
+                                  );
+                                }
+                                return GridView.builder(
+                                  padding: gridPadding,
+                                  gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                                    crossAxisCount: crossAxisCount,
+                                    childAspectRatio: childAspectRatio,
+                                    mainAxisSpacing: isCompact ? 16 : 20,
+                                    crossAxisSpacing: isCompact ? 16 : 20,
+                                  ),
+                                  itemCount: tables.length,
+                                  itemBuilder: (context, index) {
+                                    final table = tables[index];
+                                    final status = _statusLabel(table.status);
+                                    final color = _statusColor(table.status);
+                                    return InkWell(
+                                      borderRadius: BorderRadius.circular(24),
                               onTap: () {
                                 if (table.status == 'occupied' &&
                                     table.currentOrderId != null) {
@@ -174,13 +252,17 @@ class TableSelectScreen extends StatelessWidget {
                               ),
                             );
                           },
-                        );
-                      },
-                    ),
+                                );
+                              },
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
                   ),
                 ),
-              ),
-            ],
+              );
+            },
           ),
         ),
       ),


### PR DESCRIPTION
## Summary
- ajustar la distribución del menú para adaptarla a pantallas angostas y anchas
- hacer que la vista de mesas utilice rejillas y encabezados responsivos
- centrar y limitar el ancho de pedidos pendientes y del carrito con acciones apilables en móviles

## Testing
- No tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e1a0e2f5808320b607242186a864d2