### PR TITLE
Allow admins to modify closed orders

### DIFF
--- a/restaurant_app/lib/features/waiter/menu_screen.dart
+++ b/restaurant_app/lib/features/waiter/menu_screen.dart
@@ -15,12 +15,14 @@ class MenuScreen extends StatefulWidget {
     this.tableNumber,
     this.existingOrderId,
     this.initialChannel,
+    this.allowEditingClosedOrder = false,
   });
 
   final String? tableId;
   final int? tableNumber;
   final String? existingOrderId;
   final String? initialChannel;
+  final bool allowEditingClosedOrder;
 
   @override
   State<MenuScreen> createState() => _MenuScreenState();
@@ -107,6 +109,7 @@ class _MenuScreenState extends State<MenuScreen> {
         await _orderRepository.addItemsToOrder(
           orderId: widget.existingOrderId!,
           items: List<OrderItem>.from(_cart),
+          allowClosedOrders: widget.allowEditingClosedOrder,
         );
         if (!mounted) return;
         setState(() {

--- a/restaurant_app/lib/repositories/order_repository.dart
+++ b/restaurant_app/lib/repositories/order_repository.dart
@@ -126,6 +126,7 @@ class OrderRepository {
   Future<void> addItemsToOrder({
     required String orderId,
     required List<OrderItem> items,
+    bool allowClosedOrders = false,
   }) async {
     if (items.isEmpty) {
       return;
@@ -139,7 +140,7 @@ class OrderRepository {
       }
       final data = snapshot.data()!;
       final status = data['status'] as String? ?? 'open';
-      if (status != 'open') {
+      if (!allowClosedOrders && status != 'open') {
         throw StateError('El pedido ya no se puede modificar');
       }
 
@@ -177,6 +178,7 @@ class OrderRepository {
     required String orderId,
     required String menuItemId,
     required int quantity,
+    bool allowClosedOrders = false,
   }) async {
     final doc = _db.collection('orders').doc(orderId);
     await _db.runTransaction((trx) async {
@@ -186,7 +188,7 @@ class OrderRepository {
       }
       final data = snapshot.data()!;
       final status = data['status'] as String? ?? 'open';
-      if (status != 'open') {
+      if (!allowClosedOrders && status != 'open') {
         throw StateError('El pedido ya no se puede modificar');
       }
 


### PR DESCRIPTION
## Summary
- add an optional override flag in the order repository so selected operations can modify closed orders
- detect the current user's role in the cart screen to unlock admin-only edits while keeping waiters restricted
- pass the override flag when admins add products from the menu and disable UI controls when editing isn't allowed

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e27a225660832086c3d0d41463c172